### PR TITLE
Add task type as argument to builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Fibonacci serves as a good example even though it's not at all the kind of thing
 class Fib {
 
   static Task<Long> nth(long n) {
-    TaskBuilder fib = Task.named("Fib", n);
+    TaskBuilder<Long> fib = Task.ofType(Long.class).named("Fib", n);
     if (n < 2) {
       return fib
           .process(() -> n);
@@ -80,7 +80,7 @@ Here's a simple example of a `flo` task depending on two other tasks:
 
 ```java
 Task<Integer> myTask(String arg) {
-  return Task.named("MyTask", arg)
+  return Task.ofType(Integer.class).named("MyTask", arg)
       .in(() -> otherTask(arg))
       .in(() -> yetATask(arg))
       .process((otherResult, yetAResult) -> /* ... */);
@@ -126,7 +126,7 @@ class SomeExistingClass {
   }
 
   Task<Integer> task() {
-    return Task.named("EmbeddedTask", arg)
+    return Task.ofType(Integer.class).named("EmbeddedTask", arg)
         .in(() -> otherTask(arg))
         .in(() -> yetATask(arg))
         .process(this::process);
@@ -152,7 +152,7 @@ So we can easily create an endlessly recursive task (useless, but illustrative) 
 
 ```java
 Task<String> endless() {
-  return Task.named("Endless")
+  return Task.ofType(String.class).named("Endless")
       .in(() -> endless())
       .process((impossible) -> impossible);
 }
@@ -170,12 +170,12 @@ A `Task<T>` can be transformed into a data structure where a materialized view o
 
 ```java
 Task<String> first(String arg) {
-  return Task.named("First", arg)
+  return Task.ofType(String.class).named("First", arg)
       .process(() -> "hello " + arg);
 }
 
 Task<String> second(String arg) {
-  return Task.named("Second", arg)
+  return Task.ofType(String.class).named("Second", arg)
       .in(() -> first(arg))
       .process((firstResult) -> "well, " + firstResult);
 }

--- a/cli/src/main/resources/logback.xml
+++ b/cli/src/main/resources/logback.xml
@@ -1,9 +1,0 @@
-<configuration>
-    <root level="info">
-        <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-            <encoder>
-                <pattern>[%thread] %-5level %logger{0} - %msg%n</pattern>
-            </encoder>
-        </appender>
-    </root>
-</configuration>

--- a/test/src/main/java/io/rouz/scratch/Fib.java
+++ b/test/src/main/java/io/rouz/scratch/Fib.java
@@ -18,7 +18,7 @@ final class Fib {
   }
 
   static Task<Long> create(long n) {
-    TaskBuilder fib = Task.named("Fib", n);
+    TaskBuilder<Long> fib = Task.ofType(Long.class).named("Fib", n);
     if (n < 2) {
       return fib
           .process(() -> n);

--- a/test/src/main/java/io/rouz/scratch/Scratch.java
+++ b/test/src/main/java/io/rouz/scratch/Scratch.java
@@ -55,7 +55,7 @@ public class Scratch {
     Task<String> task1 = MyTask.create(parameter);
     Task<Integer> task2 = Adder.create(number, number + 2);
 
-    return Task.named("exec", "/bin/sh")
+    return Task.ofType(Exec.Result.class).named("exec", "/bin/sh")
         .in(() -> task1)
         .in(() -> task2)
         .process(Exec.exec((str, i) -> args("/bin/sh", "-c", "\"echo " + i + "\"")));
@@ -69,7 +69,7 @@ public class Scratch {
     static final int PLUS = 10;
 
     static Task<String> create(String parameter) {
-      return Task.named("MyTask", parameter)
+      return Task.ofType(String.class).named("MyTask", parameter)
           .in(() -> Adder.create(parameter.length(), PLUS))
           .in(() -> Fib.create(parameter.length()))
           .process((sum, fib) -> something(parameter, sum, fib));
@@ -83,7 +83,7 @@ public class Scratch {
 
   static class Adder {
     static Task<Integer> create(int a, int b) {
-      return Task.named("Adder", a, b).process(() -> a + b);
+      return Task.ofType(Integer.class).named("Adder", a, b).process(() -> a + b);
     }
   }
 }

--- a/test/src/test/java/io/rouz/task/processor/CliTest.java
+++ b/test/src/test/java/io/rouz/task/processor/CliTest.java
@@ -1,9 +1,9 @@
 package io.rouz.task.processor;
 
+import org.junit.Test;
+
 import io.rouz.task.Task;
 import io.rouz.task.cli.Cli;
-
-import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
@@ -32,7 +32,7 @@ public class CliTest {
   public static Task<String> standardArgs(int first, String second) {
     firstInt = first;
     secondString = second;
-    return Task.named("StandardArgs", first, second)
+    return Task.ofType(String.class).named("StandardArgs", first, second)
         .process(() -> second + " " + first * 100);
   }
 
@@ -49,7 +49,7 @@ public class CliTest {
   public static Task<String> flags(boolean flag1, boolean flag2) {
     firstFlag = flag1;
     secondFlag = flag2;
-    return Task.named("Flags", flag1, flag2)
+    return Task.ofType(String.class).named("Flags", flag1, flag2)
         .process(() -> flag1 + " " + flag2);
   }
 
@@ -64,7 +64,7 @@ public class CliTest {
   @RootTask
   public static Task<String> enums(CustomEnum enm) {
     parsedEnum = enm;
-    return Task.named("Enums", enm)
+    return Task.ofType(String.class).named("Enums", enm)
         .process(enm::toString);
   }
 
@@ -79,7 +79,7 @@ public class CliTest {
   @RootTask
   public static Task<String> customType(CustomType myType) {
     parsedType = myType;
-    return Task.named("Types", myType.content)
+    return Task.ofType(String.class).named("Types", myType.content)
         .process(() -> myType.content);
   }
 

--- a/workflow/src/main/java/io/rouz/task/dsl/TaskBuilder.java
+++ b/workflow/src/main/java/io/rouz/task/dsl/TaskBuilder.java
@@ -18,15 +18,15 @@ import io.rouz.task.TaskContext.Value;
  * Note, the inner types should never have to explicitly be mentioned or imported. The API is
  * supposed to be used through fluent calls that eventually lead to a {@link Task} instance.
  */
-public interface TaskBuilder {
+public interface TaskBuilder<Z> {
 
-  <R> Task<R> process(F0<R> code);
-  <R> Task<R> processWithContext(F1<TaskContext, Value<R>> code);
-  <A> TaskBuilder1<A> in(F0<Task<A>> task);
-  <A> TaskBuilder1<List<A>> ins(F0<List<Task<A>>> tasks);
+  Task<Z> process(F0<Z> code);
+  Task<Z> processWithContext(F1<TaskContext, Value<Z>> code);
+  <A> TaskBuilder1<A, Z> in(F0<Task<A>> task);
+  <A> TaskBuilder1<List<A>, Z> ins(F0<List<Task<A>>> tasks);
 
-  <Z> TaskBuilderC0<Z> curryTo();
-  <Z> TaskBuilderCV0<Z> curryToValue();
+  TaskBuilderC0<Z> curried();
+  TaskBuilderCV0<Z> curriedWithContext();
 
   interface TaskBuilderC0<Z> {
     <A> TaskBuilderC<A, Z, Z> in(F0<Task<A>> task);
@@ -50,23 +50,23 @@ public interface TaskBuilder {
     <B> TaskBuilderCV<List<B>, F1<A, Y>, Z> ins(F0<List<Task<B>>> tasks);
   }
 
-  interface TaskBuilder1<A> {
-    <R> Task<R> process(F1<A, R> code);
-    <R> Task<R> processWithContext(F2<TaskContext, A, Value<R>> code);
-    <B> TaskBuilder2<A, B> in(F0<Task<B>> task);
-    <B> TaskBuilder2<A, List<B>> ins(F0<List<Task<B>>> tasks);
+  interface TaskBuilder1<A, Z> {
+    Task<Z> process(F1<A, Z> code);
+    Task<Z> processWithContext(F2<TaskContext, A, Value<Z>> code);
+    <B> TaskBuilder2<A, B, Z> in(F0<Task<B>> task);
+    <B> TaskBuilder2<A, List<B>, Z> ins(F0<List<Task<B>>> tasks);
   }
 
-  interface TaskBuilder2<A, B> {
-    <R> Task<R> process(F2<A, B, R> code);
-    <R> Task<R> processWithContext(F3<TaskContext, A, B, Value<R>> code);
-    <C> TaskBuilder3<A, B, C> in(F0<Task<C>> task);
-    <C> TaskBuilder3<A, B, List<C>> ins(F0<List<Task<C>>> tasks);
+  interface TaskBuilder2<A, B, Z> {
+    Task<Z> process(F2<A, B, Z> code);
+    Task<Z> processWithContext(F3<TaskContext, A, B, Value<Z>> code);
+    <C> TaskBuilder3<A, B, C, Z> in(F0<Task<C>> task);
+    <C> TaskBuilder3<A, B, List<C>, Z> ins(F0<List<Task<C>>> tasks);
   }
 
-  interface TaskBuilder3<A, B, C> {
-    <R> Task<R> process(F3<A, B, C, R> code);
-    <R> Task<R> processWithContext(F4<TaskContext, A, B, C, Value<R>> code);
+  interface TaskBuilder3<A, B, C, Z> {
+    Task<Z> process(F3<A, B, C, Z> code);
+    Task<Z> processWithContext(F4<TaskContext, A, B, C, Value<Z>> code);
   }
 
   @FunctionalInterface

--- a/workflow/src/main/java/io/rouz/task/dsl/TaskBuilderSeed.java
+++ b/workflow/src/main/java/io/rouz/task/dsl/TaskBuilderSeed.java
@@ -1,0 +1,11 @@
+package io.rouz.task.dsl;
+
+import io.rouz.task.Task;
+
+/**
+ * The initial part of the {@link TaskBuilder} api which only holds the task
+ * type argument {@link Z}. See {@link Task#ofType(Class)}.
+ */
+public interface TaskBuilderSeed<Z> {
+  TaskBuilder<Z> named(String taskName, Object... args);
+}

--- a/workflow/src/test/java/io/rouz/task/SerializationTest.java
+++ b/workflow/src/test/java/io/rouz/task/SerializationTest.java
@@ -26,9 +26,9 @@ public class SerializationTest {
 
   @Test
   public void shouldJavaUtilSerialize() throws Exception {
-    Task<Long> task1 = Task.named("Foo", "Bar", 39)
+    Task<Long> task1 = Task.ofType(Long.class).named("Foo", "Bar", 39)
         .process(() -> 9999L);
-    Task<String> task2 = Task.named("Baz", 40)
+    Task<String> task2 = Task.ofType(String.class).named("Baz", 40)
         .in(() -> task1)
         .ins(() -> singletonList(task1))
         .process((t1, t1l) -> t1l + " hello " + (t1 + 5));
@@ -43,7 +43,7 @@ public class SerializationTest {
 
   @Test(expected = NotSerializableException.class)
   public void shouldNotSerializeWithInstanceFieldReference() throws Exception {
-    Task<String> task = Task.named("WithRef")
+    Task<String> task = Task.ofType(String.class).named("WithRef")
         .process(() -> instanceField + " causes an outer reference");
 
     serialize(task);
@@ -53,7 +53,7 @@ public class SerializationTest {
   public void shouldSerializeWithLocalReference() throws Exception {
     String local = instanceField;
 
-    Task<String> task = Task.named("WithLocalRef")
+    Task<String> task = Task.ofType(String.class).named("WithLocalRef")
         .process(() -> local + " won't cause an outer reference");
 
     serialize(task);
@@ -75,12 +75,12 @@ public class SerializationTest {
   }
 
   private Task<String> closure(String arg) {
-    return Task.named("Closed").process(() -> arg + " is enclosed");
+    return Task.ofType(String.class).named("Closed").process(() -> arg + " is enclosed");
   }
 
   @Test(expected = NotSerializableException.class)
   public void shouldNotSerializeAnonymousClass() throws Exception {
-    Task<String> task = Task.named("WithAnonClass")
+    Task<String> task = Task.ofType(String.class).named("WithAnonClass")
         .process(
             new F0<String>() {
               @Override

--- a/workflow/src/test/java/io/rouz/task/TaskEvalBehaviorTest.java
+++ b/workflow/src/test/java/io/rouz/task/TaskEvalBehaviorTest.java
@@ -49,10 +49,10 @@ public class TaskEvalBehaviorTest {
   @Test
   public void shouldMemoizeTaskProcessing() throws Exception {
     AtomicInteger counter = new AtomicInteger(0);
-    Task<Integer> count = Task.named("Count")
+    Task<Integer> count = Task.ofType(Integer.class).named("Count")
         .process(counter::incrementAndGet);
 
-    Task<Integer> sum = Task.named("Sum")
+    Task<Integer> sum = Task.ofType(Integer.class).named("Sum")
         .in(() -> count)
         .in(() -> count)
         .in(() -> count)
@@ -77,7 +77,7 @@ public class TaskEvalBehaviorTest {
         .limit(5)
         .collect(toList());
 
-    Task<Integer> sum = Task.named("Sum")
+    Task<Integer> sum = Task.ofType(Integer.class).named("Sum")
         .ins(() -> fiveInts)
         .process(this::sumInts);
 
@@ -95,7 +95,7 @@ public class TaskEvalBehaviorTest {
         .limit(5)
         .collect(toList());
 
-    Task<Integer> sum = Task.named("Sum")
+    Task<Integer> sum = Task.ofType(Integer.class).named("Sum")
         .in(() -> isEven(5))
         .ins(() -> fiveInts)
         .in(() -> isEven(2))
@@ -114,7 +114,7 @@ public class TaskEvalBehaviorTest {
         .limit(5)
         .collect(toList());
 
-    Task<Integer> sum = Task.named("Sum")
+    Task<Integer> sum = Task.ofType(Integer.class).named("Sum")
         .ins(fiveInts)
         .ins(fiveInts)
         .process((first5, second5) -> sumInts(first5) + sumInts(second5));
@@ -127,7 +127,7 @@ public class TaskEvalBehaviorTest {
   public void shouldOnlyEvaluateInputsParameterOnce() throws Exception {
     F0<Task<Integer>> countSupplier = countConstructor();
 
-    Task<Integer> sum = Task.named("Sum")
+    Task<Integer> sum = Task.ofType(Integer.class).named("Sum")
         .in(countSupplier::get)
         .in(countSupplier::get)
         .in(countSupplier::get)
@@ -144,7 +144,7 @@ public class TaskEvalBehaviorTest {
   public void shouldOnlyEvaluateCurriedInputsParameterOnce() throws Exception {
     F0<Task<Integer>> countSupplier = countConstructor();
 
-    Task<Integer> sum = Task.named("Sum").<Integer>curryTo()
+    Task<Integer> sum = Task.ofType(Integer.class).named("Sum").curried()
         .in(countSupplier::get)
         .in(countSupplier::get)
         .in(countSupplier::get)
@@ -166,7 +166,7 @@ public class TaskEvalBehaviorTest {
         .limit(5)
         .collect(toList());
 
-    Task<Integer> sum = Task.named("Sum")
+    Task<Integer> sum = Task.ofType(Integer.class).named("Sum")
         .ins(fiveInts)
         .ins(fiveInts)
         .ins(fiveInts)
@@ -188,7 +188,7 @@ public class TaskEvalBehaviorTest {
         .limit(5)
         .collect(toList());
 
-    Task<Integer> sum = Task.named("Sum").<Integer>curryTo()
+    Task<Integer> sum = Task.ofType(Integer.class).named("Sum").curried()
         .ins(fiveInts)
         .ins(fiveInts)
         .ins(fiveInts)
@@ -205,7 +205,7 @@ public class TaskEvalBehaviorTest {
 
   @Test
   public void shouldListInputIds() throws Exception {
-    Task<String> top = Task.named("Top")
+    Task<String> top = Task.ofType(String.class).named("Top")
         .in(() -> isEven(0))
         .in(() -> isEven(1))
         .in(() -> isEven(3))
@@ -224,7 +224,7 @@ public class TaskEvalBehaviorTest {
 
   @Test
   public void shouldListCurriedInputIds() throws Exception {
-    Task<String> top = Task.named("Top").<String>curryTo()
+    Task<String> top = Task.ofType(String.class).named("Top").curried()
         .in(() -> isEven(0))
         .in(() -> isEven(1))
         .in(() -> isEven(3))
@@ -245,7 +245,7 @@ public class TaskEvalBehaviorTest {
   public void shouldListInputsLazily() throws Exception {
     F0<Task<Integer>> countSupplier = countConstructor();
 
-    Task<Integer> sum = Task.named("Sum")
+    Task<Integer> sum = Task.ofType(Integer.class).named("Sum")
         .in(countSupplier::get)
         .in(countSupplier::get)
         .in(countSupplier::get)
@@ -268,7 +268,7 @@ public class TaskEvalBehaviorTest {
 
   @Test
   public void shouldLinearizeTasks() throws Exception {
-    Task<String> top = Task.named("Top")
+    Task<String> top = Task.ofType(String.class).named("Top")
         .in(() -> isEven(0))
         .in(() -> isEven(1))
         .process((a, b) -> "done");
@@ -285,7 +285,7 @@ public class TaskEvalBehaviorTest {
 
   @Test
   public void shouldFlattenStreamParameters() throws Exception {
-    Task<String> top = Task.named("Top")
+    Task<String> top = Task.ofType(String.class).named("Top")
         .ins(() -> asList(isEven(0), isEven(1)))
         .process(results -> "done " + results.size());
 
@@ -303,11 +303,11 @@ public class TaskEvalBehaviorTest {
   @Test
   public void shouldLinearizeMixedStreamAndPlainParameters() throws Exception {
     F1<Integer, Task<Integer>> evenResult = n ->
-        Task.named("EvenResult", n)
+        Task.ofType(Integer.class).named("EvenResult", n)
             .in(() -> isEven(n))
             .process(EvenResult::result);
 
-    Task<Integer> sum = Task.named("Sum")
+    Task<Integer> sum = Task.ofType(Integer.class).named("Sum")
         .in(() -> isEven(5))
         .ins(() -> asList(evenResult.apply(0), evenResult.apply(1)))
         .ins(() -> singletonList(evenResult.apply(3)))
@@ -331,8 +331,8 @@ public class TaskEvalBehaviorTest {
 
   @Test
   public void shouldBuildArbitraryDeepCurriedLambda() throws Exception {
-    final Task<Integer> curried = Task.named("Curried")
-        .<Integer>curryTo()
+    final Task<Integer> curried = Task.ofType(Integer.class).named("Curried")
+        .curried()
         .in(() -> isEven(0)) // 0
         .in(() -> isEven(1)) // 2
         .in(() -> isEven(2)) // 2
@@ -354,8 +354,8 @@ public class TaskEvalBehaviorTest {
 
   @Test
   public void shouldBuildCurriedLambdaWithLists() throws Exception {
-    final Task<Integer> curried = Task.named("Curried")
-        .<Integer>curryTo()
+    final Task<Integer> curried = Task.ofType(Integer.class).named("Curried")
+        .curried()
         .ins(() -> asList(isEven(11), isEven(20))) // [22, 20]
         .in(() -> isEven(0)) // 0
         .ins(() -> asList(isEven(1), isEven(2))) // [2, 2]
@@ -380,7 +380,7 @@ public class TaskEvalBehaviorTest {
   @Test
   public void shouldInvokeCurriedTaskWhenInputsBecomeAvailable() throws Exception {
     AwaitingConsumer<String> bValue = new AwaitingConsumer<>();
-    Task<String> task = Task.named("WithInputs").<String>curryTo()
+    Task<String> task = Task.ofType(String.class).named("WithInputs").curried()
         .in(() -> leaf("A"))
         .in(() -> leaf("B first"))
         .process(b -> {
@@ -407,7 +407,7 @@ public class TaskEvalBehaviorTest {
   @Test
   public void shouldEvaluateInputsInParallelForCurriedTask() throws Exception {
     AtomicBoolean processed = new AtomicBoolean(false);
-    Task<String> task = Task.named("WithInputs").<String>curryTo()
+    Task<String> task = Task.ofType(String.class).named("WithInputs").curried()
         .in(() -> leaf("A"))
         .in(() -> leaf("B"))
         .in(() -> leaf("C"))
@@ -422,7 +422,7 @@ public class TaskEvalBehaviorTest {
   @Test
   public void shouldEvaluateInputsInParallelForChainedTask() throws Exception {
     AtomicBoolean processed = new AtomicBoolean(false);
-    Task<String> task = Task.named("WithInputs")
+    Task<String> task = Task.ofType(String.class).named("WithInputs")
         .in(() -> leaf("A"))
         .in(() -> leaf("B"))
         .in(() -> leaf("C"))
@@ -465,7 +465,7 @@ public class TaskEvalBehaviorTest {
 
   @Test
   public void shouldInterceptProcessFunctionInContext0() throws Exception {
-    Task<String> top = Task.named("Top")
+    Task<String> top = Task.ofType(String.class).named("Top")
         .process(() -> "done");
 
     validateInterception(top, "done");
@@ -473,7 +473,7 @@ public class TaskEvalBehaviorTest {
 
   @Test
   public void shouldInterceptProcessFunctionInContext1() throws Exception {
-    Task<String> top = Task.named("Top")
+    Task<String> top = Task.ofType(String.class).named("Top")
         .in(() -> leaf("A"))
         .process((a) -> "done");
 
@@ -482,7 +482,7 @@ public class TaskEvalBehaviorTest {
 
   @Test
   public void shouldInterceptProcessFunctionInContext1L() throws Exception {
-    Task<String> top = Task.named("Top")
+    Task<String> top = Task.ofType(String.class).named("Top")
         .ins(() -> singletonList(leaf("A")))
         .process((a) -> "done");
 
@@ -491,7 +491,7 @@ public class TaskEvalBehaviorTest {
 
   @Test
   public void shouldInterceptProcessFunctionInContext2() throws Exception {
-    Task<String> top = Task.named("Top")
+    Task<String> top = Task.ofType(String.class).named("Top")
         .in(() -> leaf("A"))
         .in(() -> leaf("B"))
         .process((a, b) -> "done");
@@ -501,7 +501,7 @@ public class TaskEvalBehaviorTest {
 
   @Test
   public void shouldInterceptProcessFunctionInContext2L() throws Exception {
-    Task<String> top = Task.named("Top")
+    Task<String> top = Task.ofType(String.class).named("Top")
         .ins(() -> singletonList(leaf("A")))
         .ins(() -> singletonList(leaf("B")))
         .process((a, b) -> "done");
@@ -511,7 +511,7 @@ public class TaskEvalBehaviorTest {
 
   @Test
   public void shouldInterceptProcessFunctionInContext3() throws Exception {
-    Task<String> top = Task.named("Top")
+    Task<String> top = Task.ofType(String.class).named("Top")
         .in(() -> leaf("A"))
         .in(() -> leaf("B"))
         .in(() -> leaf("C"))
@@ -522,7 +522,7 @@ public class TaskEvalBehaviorTest {
 
   @Test
   public void shouldInterceptProcessFunctionInContext0C() throws Exception {
-    Task<String> top = Task.named("Top")
+    Task<String> top = Task.ofType(String.class).named("Top")
         .processWithContext((tc) -> tc.immediateValue("done"));
 
     validateInterception(top, "done");
@@ -530,7 +530,7 @@ public class TaskEvalBehaviorTest {
 
   @Test
   public void shouldInterceptProcessFunctionInContextC() throws Exception {
-    Task<String> top = Task.named("Top")
+    Task<String> top = Task.ofType(String.class).named("Top")
         .in(() -> leaf("A"))
         .in(() -> leaf("B"))
         .processWithContext((tc, a, b) -> tc.immediateValue("done"));
@@ -540,7 +540,7 @@ public class TaskEvalBehaviorTest {
 
   @Test
   public void shouldInterceptProcessFunctionInContextCL() throws Exception {
-    Task<String> top = Task.named("Top")
+    Task<String> top = Task.ofType(String.class).named("Top")
         .ins(() -> singletonList(leaf("A")))
         .ins(() -> singletonList(leaf("B")))
         .processWithContext((tc, a, b) -> tc.immediateValue("done"));
@@ -550,7 +550,7 @@ public class TaskEvalBehaviorTest {
 
   @Test
   public void shouldInterceptCurriedProcessFunctionInContext() throws Exception {
-    Task<String> top = Task.named("Top").<String>curryTo()
+    Task<String> top = Task.ofType(String.class).named("Top").curried()
         .in(() -> leaf("A"))
         .in(() -> leaf("B"))
         .process(b -> {
@@ -566,7 +566,7 @@ public class TaskEvalBehaviorTest {
 
   @Test
   public void shouldInterceptCurriedProcessFunctionInContextL() throws Exception {
-    Task<String> top = Task.named("Top").<String>curryTo()
+    Task<String> top = Task.ofType(String.class).named("Top").curried()
         .ins(() -> singletonList(leaf("A")))
         .ins(() -> singletonList(leaf("B")))
         .process(b -> {
@@ -582,7 +582,7 @@ public class TaskEvalBehaviorTest {
 
   @Test
   public void shouldInterceptCurriedProcessFunctionInContextC() throws Exception {
-    Task<String> top = Task.named("Top").<String>curryToValue()
+    Task<String> top = Task.ofType(String.class).named("Top").curriedWithContext()
         .in(() -> leaf("A"))
         .in(() -> leaf("B"))
         .process(tc -> b -> {
@@ -598,7 +598,7 @@ public class TaskEvalBehaviorTest {
 
   @Test
   public void shouldInterceptCurriedProcessFunctionInContextCL() throws Exception {
-    Task<String> top = Task.named("Top").<String>curryToValue()
+    Task<String> top = Task.ofType(String.class).named("Top").curriedWithContext()
         .ins(() -> singletonList(leaf("A")))
         .ins(() -> singletonList(leaf("B")))
         .process(tc -> b -> {
@@ -645,14 +645,14 @@ public class TaskEvalBehaviorTest {
   }
 
   private Task<String> leaf(String s) {
-    return Task.named("Leaf", s).process(() -> s);
+    return Task.ofType(String.class).named("Leaf", s).process(() -> s);
   }
 
   private F0<Task<Integer>> countConstructor() {
     AtomicInteger counter = new AtomicInteger(0);
     return () -> {
       int n = counter.incrementAndGet();
-      return Task.named("Count", n)
+      return Task.ofType(Integer.class).named("Count", n)
           .process(() -> n);
     };
   }
@@ -662,7 +662,7 @@ public class TaskEvalBehaviorTest {
   }
 
   private Task<EvenResult> isEven(int n) {
-    TaskBuilder isEven = Task.named("IsEven", n);
+    TaskBuilder<EvenResult> isEven = Task.ofType(EvenResult.class).named("IsEven", n);
 
     if (n % 2 == 0) {
       return isEven.process(() -> new WasEven(n));
@@ -674,7 +674,7 @@ public class TaskEvalBehaviorTest {
   }
 
   private Task<Integer> evenify(int n) {
-    return Task.named("Evenify", n)
+    return Task.ofType(Integer.class).named("Evenify", n)
         .process(() -> n * 2);
   }
 

--- a/workflow/src/test/java/io/rouz/task/TaskInfoTest.java
+++ b/workflow/src/test/java/io/rouz/task/TaskInfoTest.java
@@ -28,13 +28,13 @@ public class TaskInfoTest {
   }
 
   private Task<String> first() {
-    return Task.named("First")
+    return Task.ofType(String.class).named("First")
         .in(() -> second(1))
         .process((s) -> "foo");
   }
 
   private Task<String> second(int i) {
-    return Task.named("Second", i)
+    return Task.ofType(String.class).named("Second", i)
         .in(() -> second(i))
         .process((self) -> "bar");
   }

--- a/workflow/src/test/java/io/rouz/task/TaskTest.java
+++ b/workflow/src/test/java/io/rouz/task/TaskTest.java
@@ -7,6 +7,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.rouz.task.TaskContext.Promise;
 
 import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -29,7 +30,7 @@ public class TaskTest {
 
   @Test
   public void shouldEvaluate0ND() throws Exception {
-    Task<String> task = Task.named("InContext")
+    Task<String> task = Task.ofType(String.class).named("InContext")
         .process(() -> "constant");
 
     AwaitingConsumer<String> val = new AwaitingConsumer<>();
@@ -45,7 +46,7 @@ public class TaskTest {
   @Test
   public void shouldEvaluate0NC() throws Exception {
     AtomicReference<Promise<String>> promiseRef = new AtomicReference<>();
-    Task<String> task = Task.named("InContext").processWithContext(tc -> {
+    Task<String> task = Task.ofType(String.class).named("InContext").processWithContext(tc -> {
       Promise<String> promise = tc.promise();
       promiseRef.set(promise);
       return promise.value();
@@ -58,7 +59,7 @@ public class TaskTest {
 
   @Test
   public void shouldEvaluate1ND_I() throws Exception {
-    Task<String> task = Task.named("InContext")
+    Task<String> task = Task.ofType(String.class).named("InContext")
         .in(() -> leaf("A"))
         .process((a) -> "done: " + a);
 
@@ -67,7 +68,7 @@ public class TaskTest {
 
   @Test
   public void shouldEvaluate1ND_L() throws Exception {
-    Task<String> task = Task.named("InContext")
+    Task<String> task = Task.ofType(String.class).named("InContext")
         .ins(() -> asList(leaf("A"), leaf("B")))
         .process((ab) -> "done: " + ab);
 
@@ -77,7 +78,7 @@ public class TaskTest {
   @Test
   public void shouldEvaluate1NC_I() throws Exception {
     AtomicReference<Promise<String>> promiseRef = new AtomicReference<>();
-    Task<String> task = Task.named("InContext")
+    Task<String> task = Task.ofType(String.class).named("InContext")
         .in(() -> leaf("A"))
         .processWithContext((tc, a) -> {
           Promise<String> promise = tc.promise();
@@ -91,7 +92,7 @@ public class TaskTest {
   @Test
   public void shouldEvaluate1NC_L() throws Exception {
     AtomicReference<Promise<String>> promiseRef = new AtomicReference<>();
-    Task<String> task = Task.named("InContext")
+    Task<String> task = Task.ofType(String.class).named("InContext")
         .ins(() -> asList(leaf("A"), leaf("B")))
         .processWithContext((tc, ab) -> {
           Promise<String> promise = tc.promise();
@@ -106,7 +107,7 @@ public class TaskTest {
 
   @Test
   public void shouldEvaluate2ND_II() throws Exception {
-    Task<String> task = Task.named("InContext")
+    Task<String> task = Task.ofType(String.class).named("InContext")
         .in(() -> leaf("A"))
         .in(() -> leaf("B"))
         .process((a, b) -> "done: " + a + " - " + b);
@@ -116,7 +117,7 @@ public class TaskTest {
 
   @Test
   public void shouldEvaluate2ND_IL() throws Exception {
-    Task<String> task = Task.named("InContext")
+    Task<String> task = Task.ofType(String.class).named("InContext")
         .in(() -> leaf("A"))
         .ins(() -> asList(leaf("B"), leaf("C")))
         .process((a, bc) -> "done: " + a + " - " + bc);
@@ -127,7 +128,7 @@ public class TaskTest {
   @Test
   public void shouldEvaluate2NC_II() throws Exception {
     AtomicReference<Promise<String>> promiseRef = new AtomicReference<>();
-    Task<String> task = Task.named("InContext")
+    Task<String> task = Task.ofType(String.class).named("InContext")
         .in(() -> leaf("A"))
         .in(() -> leaf("B"))
         .processWithContext((tc, a, b) -> {
@@ -142,7 +143,7 @@ public class TaskTest {
   @Test
   public void shouldEvaluate2NC_IL() throws Exception {
     AtomicReference<Promise<String>> promiseRef = new AtomicReference<>();
-    Task<String> task = Task.named("InContext")
+    Task<String> task = Task.ofType(String.class).named("InContext")
         .in(() -> leaf("A"))
         .ins(() -> asList(leaf("B"), leaf("C")))
         .processWithContext((tc, a, bc) -> {
@@ -158,7 +159,7 @@ public class TaskTest {
 
   @Test
   public void shouldEvaluate3ND_III() throws Exception {
-    Task<String> task = Task.named("InContext")
+    Task<String> task = Task.ofType(String.class).named("InContext")
         .in(() -> leaf("A"))
         .in(() -> leaf("B"))
         .in(() -> leaf("C"))
@@ -169,7 +170,7 @@ public class TaskTest {
 
   @Test
   public void shouldEvaluate3ND_IIL() throws Exception {
-    Task<String> task = Task.named("InContext")
+    Task<String> task = Task.ofType(String.class).named("InContext")
         .in(() -> leaf("A"))
         .in(() -> leaf("B"))
         .ins(() -> asList(leaf("C"), leaf("D")))
@@ -181,7 +182,7 @@ public class TaskTest {
   @Test
   public void shouldEvaluate3NC_III() throws Exception {
     AtomicReference<Promise<String>> promiseRef = new AtomicReference<>();
-    Task<String> task = Task.named("InContext")
+    Task<String> task = Task.ofType(String.class).named("InContext")
         .in(() -> leaf("A"))
         .in(() -> leaf("B"))
         .in(() -> leaf("C"))
@@ -197,7 +198,7 @@ public class TaskTest {
   @Test
   public void shouldEvaluate3NC_IIL() throws Exception {
     AtomicReference<Promise<String>> promiseRef = new AtomicReference<>();
-    Task<String> task = Task.named("InContext")
+    Task<String> task = Task.ofType(String.class).named("InContext")
         .in(() -> leaf("A"))
         .in(() -> leaf("B"))
         .ins(() -> asList(leaf("C"), leaf("D")))
@@ -215,7 +216,7 @@ public class TaskTest {
 
   @Test
   public void shouldEvaluate1RN_I() throws Exception {
-    Task<String> task = Task.named("InContext").<String>curryTo()
+    Task<String> task = Task.ofType(String.class).named("InContext").curried()
         .in(() -> leaf("A"))
         .process(a -> "done: " + a);
 
@@ -224,7 +225,7 @@ public class TaskTest {
 
   @Test
   public void shouldEvaluate1RN_L() throws Exception {
-    Task<String> task = Task.named("InContext").<String>curryTo()
+    Task<String> task = Task.ofType(String.class).named("InContext").curried()
         .ins(() -> asList(leaf("A"), leaf("B")))
         .process(ab -> "done: " + ab);
 
@@ -234,7 +235,7 @@ public class TaskTest {
   @Test
   public void shouldEvaluate1RC_I() throws Exception {
     AtomicReference<Promise<String>> promiseRef = new AtomicReference<>();
-    Task<String> task = Task.named("InContext").<String>curryToValue()
+    Task<String> task = Task.ofType(String.class).named("InContext").curriedWithContext()
         .in(() -> leaf("A"))
         .process(tc -> a -> {
           Promise<String> promise = tc.promise();
@@ -248,7 +249,7 @@ public class TaskTest {
   @Test
   public void shouldEvaluate1RC_L() throws Exception {
     AtomicReference<Promise<String>> promiseRef = new AtomicReference<>();
-    Task<String> task = Task.named("InContext").<String>curryToValue()
+    Task<String> task = Task.ofType(String.class).named("InContext").curriedWithContext()
         .ins(() -> asList(leaf("A"), leaf("B")))
         .process(tc -> ab -> {
           Promise<String> promise = tc.promise();
@@ -263,7 +264,7 @@ public class TaskTest {
 
   @Test
   public void shouldEvaluate2RN_II() throws Exception {
-    Task<String> task = Task.named("InContext").<String>curryTo()
+    Task<String> task = Task.ofType(String.class).named("InContext").curried()
         .in(() -> leaf("A"))
         .in(() -> leaf("B"))
         .process(b -> a -> "done: " + a  + " - " + b);
@@ -273,7 +274,7 @@ public class TaskTest {
 
   @Test
   public void shouldEvaluate2RN_IL() throws Exception {
-    Task<String> task = Task.named("InContext").<String>curryTo()
+    Task<String> task = Task.ofType(String.class).named("InContext").curried()
         .in(() -> leaf("A"))
         .ins(() -> asList(leaf("B"), leaf("C")))
         .process(bc -> a -> "done: " + a + " - " + bc);
@@ -284,7 +285,7 @@ public class TaskTest {
   @Test
   public void shouldEvaluate2RC_II() throws Exception {
     AtomicReference<Promise<String>> promiseRef = new AtomicReference<>();
-    Task<String> task = Task.named("InContext").<String>curryToValue()
+    Task<String> task = Task.ofType(String.class).named("InContext").curriedWithContext()
         .in(() -> leaf("A"))
         .in(() -> leaf("B"))
         .process(tc -> b -> a -> {
@@ -299,7 +300,7 @@ public class TaskTest {
   @Test
   public void shouldEvaluate2RC_IL() throws Exception {
     AtomicReference<Promise<String>> promiseRef = new AtomicReference<>();
-    Task<String> task = Task.named("InContext").<String>curryToValue()
+    Task<String> task = Task.ofType(String.class).named("InContext").curriedWithContext()
         .in(() -> leaf("A"))
         .ins(() -> asList(leaf("B"), leaf("C")))
         .process(tc -> bc -> a -> {
@@ -309,6 +310,61 @@ public class TaskTest {
         });
 
     validatePromiseEvaluation(task, promiseRef, " - A - [B, C]", leaf("A"), leaf("B"), leaf("C"));
+  }
+
+  // ==============================================================================================
+
+  @Test
+  public void shouldHaveClassOfTaskType() throws Exception {
+    Task<String> task0 = Task.ofType(String.class).named("WithType")
+        .process(() -> "");
+    Task<String> task1 = Task.ofType(String.class).named("WithType")
+        .in(() -> leaf("A"))
+        .process((a) -> a);
+    Task<String> task1c = Task.ofType(String.class).named("WithType").curried()
+        .in(() -> leaf("A"))
+        .process(a -> a);
+    Task<String> task1cc = Task.ofType(String.class).named("WithType").curriedWithContext()
+        .in(() -> leaf("A"))
+        .process(tc -> tc::immediateValue);
+    Task<String> task2 = Task.ofType(String.class).named("WithType")
+        .in(() -> leaf("A"))
+        .in(() -> leaf("B"))
+        .process((a, b) -> a + " - " + b);
+    Task<String> task2c = Task.ofType(String.class).named("WithType").curried()
+        .in(() -> leaf("A"))
+        .in(() -> leaf("B"))
+        .process(a -> b -> a + " - " + b);
+    Task<String> task2cc = Task.ofType(String.class).named("WithType").curriedWithContext()
+        .in(() -> leaf("A"))
+        .in(() -> leaf("B"))
+        .process(tc -> a -> b -> tc.immediateValue(a + " - " + b));
+    Task<String> task3 = Task.ofType(String.class).named("WithType")
+        .in(() -> leaf("A"))
+        .in(() -> leaf("B"))
+        .in(() -> leaf("C"))
+        .process((a, b, c) -> a + " - " + b +" - " + c);
+    Task<String> task3c = Task.ofType(String.class).named("WithType").curried()
+        .in(() -> leaf("A"))
+        .in(() -> leaf("B"))
+        .in(() -> leaf("C"))
+        .process(a -> b -> c -> a + " - " + b +" - " + c);
+    Task<String> task3cc = Task.ofType(String.class).named("WithType").curriedWithContext()
+        .in(() -> leaf("A"))
+        .in(() -> leaf("B"))
+        .in(() -> leaf("C"))
+        .process(tc -> a -> b -> c -> tc.immediateValue(a + " - " + b +" - " + c));
+
+    assertThat(task0.type(), equalTo(String.class));
+    assertThat(task1.type(), equalTo(String.class));
+    assertThat(task1c.type(), equalTo(String.class));
+    assertThat(task1cc.type(), equalTo(String.class));
+    assertThat(task2.type(), equalTo(String.class));
+    assertThat(task2c.type(), equalTo(String.class));
+    assertThat(task2cc.type(), equalTo(String.class));
+    assertThat(task3.type(), equalTo(String.class));
+    assertThat(task3c.type(), equalTo(String.class));
+    assertThat(task3cc.type(), equalTo(String.class));
   }
 
   // Validators ===================================================================================
@@ -373,6 +429,6 @@ public class TaskTest {
   }
 
   Task<String> leaf(String s) {
-    return Task.named("Leaf", s).process(() -> s);
+    return Task.ofType(String.class).named("Leaf", s).process(() -> s);
   }
 }


### PR DESCRIPTION
In order to support encoding/decoding of task values from `TaskContext`, the Class of the task type needs to be stored with the task.