### PR TITLE
Add currentTaskId method to TaskContext

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,12 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/workflow/src/main/java/io/rouz/task/TaskBuilders.java
+++ b/workflow/src/main/java/io/rouz/task/TaskBuilders.java
@@ -20,6 +20,7 @@ import io.rouz.task.dsl.TaskBuilder.TaskBuilderC0;
 import io.rouz.task.dsl.TaskBuilder.TaskBuilderCV;
 import io.rouz.task.dsl.TaskBuilder.TaskBuilderCV0;
 
+import static io.rouz.task.TaskContextWithId.withId;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -215,7 +216,8 @@ final class TaskBuilders {
 
     @Override
     public Task<Z> process(F1<TaskContext, F1<A, Y>> code) {
-      EvalClosure<Z> closure = tc -> evaluator.<Z>enclose((a) -> code.apply(tc).apply(a)).eval(tc);
+      EvalClosure<Z> closure =
+          tc -> evaluator.<Z>enclose((a) -> code.apply(withId(tc, taskId)).apply(a)).eval(tc);
       return Task.create(inputs, type, closure, taskId);
     }
 
@@ -266,7 +268,8 @@ final class TaskBuilders {
 
     @Override
     public Task<Z> processWithContext(F2<TaskContext, A, Value<Z>> code) {
-      EvalClosure<Z> closure = tc -> valEvaluator.<Z>enclose((a) -> code.apply(tc, a)).eval(tc);
+      EvalClosure<Z> closure =
+          tc -> valEvaluator.<Z>enclose((a) -> code.apply(withId(tc, taskId), a)).eval(tc);
       return Task.create(inputs, type, closure, taskId);
     }
 
@@ -330,7 +333,8 @@ final class TaskBuilders {
 
     @Override
     public Task<Z> processWithContext(F3<TaskContext, A, B, Value<Z>> code) {
-      EvalClosure<Z> closure = tc -> valEvaluator.<Z>enclose((a, b) -> code.apply(tc, a, b)).eval(tc);
+      EvalClosure<Z> closure =
+          tc -> valEvaluator.<Z>enclose((a, b) -> code.apply(withId(tc, taskId), a, b)).eval(tc);
       return Task.create(inputs, type, closure, taskId);
     }
 
@@ -394,7 +398,8 @@ final class TaskBuilders {
 
     @Override
     public Task<Z> processWithContext(F4<TaskContext, A, B, C, Value<Z>> code) {
-      EvalClosure<Z> closure = tc -> valEvaluator.<Z>enclose((a, b, c) -> code.apply(tc, a, b, c)).eval(tc);
+      EvalClosure<Z> closure =
+          tc -> valEvaluator.<Z>enclose((a, b, c) -> code.apply(withId(tc, taskId), a, b, c)).eval(tc);
       return Task.create(inputs, type, closure, taskId);
     }
   }
@@ -513,7 +518,7 @@ final class TaskBuilders {
   }
 
   private static <R> EvalClosure<R> gatedVal(TaskId taskId, F1<TaskContext, Value<R>> code) {
-    return tc -> tc.invokeProcessFn(taskId, () -> code.apply(tc));
+    return tc -> tc.invokeProcessFn(taskId, () -> code.apply(withId(tc, taskId)));
   }
 
   /**

--- a/workflow/src/main/java/io/rouz/task/TaskContext.java
+++ b/workflow/src/main/java/io/rouz/task/TaskContext.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -61,6 +62,22 @@ public interface TaskContext {
    */
   default <T> Value<T> invokeProcessFn(TaskId taskId, F0<Value<T>> processFn) {
     return processFn.get();
+  }
+
+  /**
+   * When called from within any of the functions passed to {@code processWithContext}, this
+   * method will return the {@link TaskId} of the task being processed. Otherwise an empty value
+   * will be returned.
+   *
+   * The return value of this method is stable for each instance of {@link TaskContext} that is
+   * passed into the process functions. Calls from multiple threads will see the same result as
+   * longs as the calls are made to the same instance.
+   *
+   * @return The id of the task that is being evaluated or empty if called from outside of a
+   * process function
+   */
+  default Optional<TaskId> currentTaskId() {
+    return Optional.empty();
   }
 
   /**

--- a/workflow/src/main/java/io/rouz/task/TaskContextWithId.java
+++ b/workflow/src/main/java/io/rouz/task/TaskContextWithId.java
@@ -1,0 +1,64 @@
+package io.rouz.task;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collector;
+
+import io.rouz.task.dsl.TaskBuilder;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A {@link TaskContext} that overrides {@link #currentTaskId()} to return a specific {@link TaskId}.
+ */
+class TaskContextWithId implements TaskContext {
+
+  private final TaskContext delegate;
+  private final TaskId taskId;
+
+  private TaskContextWithId(TaskContext delegate, TaskId taskId) {
+    this.delegate = requireNonNull(delegate);
+    this.taskId = requireNonNull(taskId);
+  }
+
+  static TaskContext withId(TaskContext delegate, TaskId taskId) {
+    return new TaskContextWithId(delegate, taskId);
+  }
+
+  @Override
+  public Optional<TaskId> currentTaskId() {
+    return Optional.of(taskId);
+  }
+
+  // === forwarding methods =======================================================================
+
+  @Override
+  public <T> Value<T> evaluate(Task<T> task) {
+    return delegate.evaluate(task);
+  }
+
+  @Override
+  public <T> Value<T> invokeProcessFn(TaskId taskId, TaskBuilder.F0<Value<T>> processFn) {
+    return delegate.invokeProcessFn(taskId, processFn);
+  }
+
+  @Override
+  public <T> Value<T> value(TaskBuilder.F0<T> value) {
+    return delegate.value(value);
+  }
+
+  @Override
+  public <T> Value<T> immediateValue(T value) {
+    return delegate.immediateValue(value);
+  }
+
+  @Override
+  public <T> Promise<T> promise() {
+    return delegate.promise();
+  }
+
+  @Override
+  public <T> Collector<Value<T>, ?, Value<List<T>>> toValueList() {
+    return delegate.toValueList();
+  }
+}

--- a/workflow/src/test/java/io/rouz/task/TaskContextWithIdTest.java
+++ b/workflow/src/test/java/io/rouz/task/TaskContextWithIdTest.java
@@ -1,0 +1,90 @@
+package io.rouz.task;
+
+import org.junit.Test;
+
+import java.util.Optional;
+import java.util.stream.Collector;
+
+import io.rouz.task.dsl.TaskBuilder;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TaskContextWithIdTest {
+
+  static final Task<String> TASK = Task.create(() -> "", String.class, "foo");
+  static final TaskBuilder.F0<TaskContext.Value<Object>> FN = () -> null;
+
+  TaskContext delegate = mock(TaskContext.class);
+  TaskId taskId = TaskId.create("TestTAsk", "a", "b");
+
+  TaskContext sut = TaskContextWithId.withId(delegate, taskId);
+
+  @Test
+  public void testEmptyDefault() throws Exception {
+    assertThat(TaskContext.inmem().currentTaskId(), is(Optional.empty()));
+  }
+
+  @Test
+  public void testCurrentTaskId() throws Exception {
+    assertThat(sut.currentTaskId(), is(Optional.of(taskId)));
+  }
+
+  @Test
+  public void testEvaluateDelegates() throws Exception {
+    //noinspection unchecked
+    TaskContext.Value<String> value = mock(TaskContext.Value.class);
+    when(delegate.evaluate(TASK)).thenReturn(value);
+
+    assertThat(sut.evaluate(TASK), is(value));
+  }
+
+  @Test
+  public void testInvokeProcessFnDelegates() throws Exception {
+    //noinspection unchecked
+    TaskContext.Value<Object> value = mock(TaskContext.Value.class);
+    when(delegate.invokeProcessFn(TASK.id(), FN)).thenReturn(value);
+
+    assertThat(sut.invokeProcessFn(TASK.id(), FN), is(value));
+  }
+
+  @Test
+  public void testValueDelegates() throws Exception {
+    //noinspection unchecked
+    TaskContext.Value<Object> value = mock(TaskContext.Value.class);
+    TaskBuilder.F0<Object> fn = Object::new;
+    when(delegate.value(fn)).thenReturn(value);
+
+    sut.value(fn);
+  }
+
+  @Test
+  public void testImmediateValueDelegates() throws Exception {
+    //noinspection unchecked
+    TaskContext.Value<String> value = mock(TaskContext.Value.class);
+    when(delegate.immediateValue("STRING")).thenReturn(value);
+
+    assertThat(sut.immediateValue("STRING"), is(value));
+  }
+
+  @Test
+  public void testPromiseDelegates() throws Exception {
+    //noinspection unchecked
+    TaskContext.Promise<String> promise = mock(TaskContext.Promise.class);
+    when(delegate.<String>promise()).thenReturn(promise);
+
+    assertThat(sut.promise(), is(promise));
+  }
+
+  @Test
+  public void testToValueListDelegates() throws Exception {
+    Collector collector = TaskContext.inmem().toValueList();
+    //noinspection unchecked
+    when(delegate.toValueList()).thenReturn(collector);
+
+    // todo: this method does not really belong to the interface
+    assertThat(sut.toValueList(), is(collector));
+  }
+}

--- a/workflow/src/test/java/io/rouz/task/TaskEvalBehaviorTest.java
+++ b/workflow/src/test/java/io/rouz/task/TaskEvalBehaviorTest.java
@@ -405,6 +405,72 @@ public class TaskEvalBehaviorTest {
   }
 
   @Test
+  public void shouldGetTaskIdFromContext0() throws Exception {
+    Task<TaskId> task = Task.named("MyOwnId").ofType(TaskId.class)
+        .processWithContext(tc -> tc.immediateValue(tc.currentTaskId().get()));
+
+    validateReturnsOwnTaskId(task);
+  }
+
+  @Test
+  public void shouldGetTaskIdFromContext1() throws Exception {
+    Task<TaskId> task = Task.named("MyOwnId").ofType(TaskId.class)
+        .in(() -> leaf("A"))
+        .processWithContext((tc, a) -> tc.immediateValue(tc.currentTaskId().get()));
+
+    validateReturnsOwnTaskId(task);
+  }
+
+  @Test
+  public void shouldGetTaskIdFromContext2() throws Exception {
+    Task<TaskId> task = Task.named("MyOwnId").ofType(TaskId.class)
+        .in(() -> leaf("A"))
+        .in(() -> leaf("B"))
+        .processWithContext((tc, a, b) -> tc.immediateValue(tc.currentTaskId().get()));
+
+    validateReturnsOwnTaskId(task);
+  }
+
+  @Test
+  public void shouldGetTaskIdFromContext3() throws Exception {
+    Task<TaskId> task = Task.named("MyOwnId").ofType(TaskId.class)
+        .in(() -> leaf("A"))
+        .in(() -> leaf("B"))
+        .in(() -> leaf("C"))
+        .processWithContext((tc, a, b, c) -> tc.immediateValue(tc.currentTaskId().get()));
+
+    validateReturnsOwnTaskId(task);
+  }
+
+  @Test
+  public void shouldGetTaskIdFromContextC1() throws Exception {
+    Task<TaskId> task = Task.named("MyOwnId").ofType(TaskId.class).curriedWithContext()
+        .in(() -> leaf("A"))
+        .process(tc -> a -> tc.immediateValue(tc.currentTaskId().get()));
+
+    validateReturnsOwnTaskId(task);
+  }
+
+  @Test
+  public void shouldGetTaskIdFromContextC2() throws Exception {
+    Task<TaskId> task = Task.named("MyOwnId").ofType(TaskId.class).curriedWithContext()
+        .in(() -> leaf("A"))
+        .in(() -> leaf("b"))
+        .process(tc -> a -> b -> tc.immediateValue(tc.currentTaskId().get()));
+
+    validateReturnsOwnTaskId(task);
+  }
+
+  private void validateReturnsOwnTaskId(Task<TaskId> task) throws InterruptedException {
+    AwaitingConsumer<TaskId> val = new AwaitingConsumer<>();
+    TaskContext.inmem()
+        .evaluate(task)
+        .consume(val);
+
+    assertThat(val.awaitAndGet(), is(task.id()));
+  }
+
+  @Test
   public void shouldEvaluateInputsInParallelForCurriedTask() throws Exception {
     AtomicBoolean processed = new AtomicBoolean(false);
     Task<String> task = Task.named("WithInputs").ofType(String.class).curried()


### PR DESCRIPTION
This enabled task utilities to give the user useful information about the task being evaluated. The method is intended to be used from the functions passed to any of the `processWithContext(...)` builders.

fixes #15 