### PR TITLE
Memoizing context

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,9 +59,14 @@
                 <version>1.0-rc2</version>
             </dependency>
             <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>19.0</version>
+            </dependency>
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.12</version>
+                <version>1.7.16</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
@@ -89,13 +94,6 @@
                 <groupId>com.google.truth</groupId>
                 <artifactId>truth</artifactId>
                 <version>0.24</version>
-            </dependency>
-
-            <!-- version resolution -->
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>18.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -23,6 +23,16 @@
         </dependency>
 
         <dependency>
+            <groupId>com.spotify</groupId>
+            <artifactId>apollo-api</artifactId>
+            <version>1.2.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
+            <version>1.6.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.7.0-rc1</version>

--- a/test/src/main/java/io/rouz/scratch/persist/Dump.java
+++ b/test/src/main/java/io/rouz/scratch/persist/Dump.java
@@ -1,0 +1,283 @@
+package io.rouz.scratch.persist;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Maps;
+
+import com.spotify.apollo.Client;
+import com.spotify.apollo.Request;
+import com.spotify.apollo.Response;
+import com.spotify.apollo.Status;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import io.rouz.flo.Fn;
+import io.rouz.flo.Task;
+import io.rouz.flo.TaskContext;
+import io.rouz.flo.TaskId;
+import io.rouz.flo.context.AsyncContext;
+import okio.ByteString;
+
+/**
+ * TODO: document.
+ */
+public class Dump extends AsyncContext {
+
+  private static final String LOCK_PATH = "/lock";
+
+  private final ScheduledExecutorService scheduler;
+  private final ExecutorService executor;
+  private final ConcurrentMap<TaskId, EvalBundle<?>> ongoing = Maps.newConcurrentMap();
+//  private final Logging logging;
+
+  private final Client client = r -> CompletableFuture.completedFuture(null);
+
+  protected Dump(
+      ScheduledExecutorService scheduledExecutorService,
+      ExecutorService executor) {
+    super(executor);
+    this.scheduler = Objects.requireNonNull(scheduledExecutorService);
+    this.executor = Objects.requireNonNull(executor);
+  }
+
+  @Override
+  public <T> TaskContext.Value<T> invokeProcessFn(TaskId taskId, Fn<TaskContext.Value<T>> processFn) {
+    final EvalBundle<T> evalBundle = lookupBundle(taskId);
+    final TaskContext.Promise<T> promise = promise();
+    final LockHolder lockHolder = new LockHolder(taskId, "/", scheduler);
+    final ProcessBundle<T> processBundle =
+        new ProcessBundle<>(evalBundle, lockHolder, processFn, promise);
+
+    processBundle.process();
+
+    return promise.value();
+  }
+
+  private Runnable onExecutor(Runnable runnable) {
+    return () -> executor.submit(runnable);
+  }
+
+  private <T> Consumer<T> onExecutor(Consumer<T> consumer) {
+    return (t) -> executor.submit(() -> consumer.accept(t));
+  }
+
+  private <T> void chain(TaskContext.Value<T> value, TaskContext.Promise<T> promise) {
+    value.consume(promise::set);
+    value.onFail(promise::fail);
+  }
+
+  private static <T> Optional<Function<T, ByteString>> findEncoder(Class<T> type) {
+    for (Method method : type.getDeclaredMethods()) {
+      if (method.getDeclaredAnnotation(Encoder.class) != null) {
+        // todo: validate signature
+        return Optional.of(t -> (ByteString) invokeAndPropagateException(method, t));
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  private static Object invokeAndPropagateException(Method method, Object... args) {
+    try {
+      return method.invoke(/* static */ null, args);
+    } catch (IllegalAccessException | InvocationTargetException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  private <T> EvalBundle<T> lookupBundle(TaskId taskId) {
+    EvalBundle<T> spin;
+    do {
+      //noinspection unchecked
+      spin = (EvalBundle<T>) ongoing.get(taskId);
+    } while (spin == null);
+    return spin;
+  }
+
+  private Request request(String method) {
+    return Request.forUri("/" + LOCK_PATH, method);
+  }
+
+  static ByteString json(TaskId taskId) {
+    // todo: types
+    return ByteString.encodeUtf8("{\"task_id\":\"" + taskId.toString() + "\"}");
+  }
+
+  static ByteString json(TaskId taskId, ByteString data) {
+    // todo: types
+    return ByteString.encodeUtf8("{\"task_id\":\"" + taskId.toString() + "\", \"data\":\""
+                                 + data.base64() + "\"}");
+  }
+
+  private final class EvalBundle<T> {
+
+    private final Task<T> task;
+    private final TaskContext.Promise<T> promise;
+    private final Optional<Function<ByteString, T>> decoder;
+
+    private EvalBundle(Task<T> task, TaskContext.Promise<T> promise, Optional<Function<ByteString, T>> decoder) {
+      this.task = task;
+      this.promise = promise;
+      this.decoder = decoder;
+    }
+
+    private void fetchOrElse(TaskContext.Promise<T> promise, Runnable orElse) {
+      Preconditions.checkState(decoder.isPresent(), "Must have decoder when fetching existing");
+
+      final Request getRequest = request("GET")
+          .withPayload(json(task.id()));
+
+      client.send(getRequest)
+          .handleAsync(parseExisting(decoder.get()), executor) // fixme: parse errors should fail
+          .thenAcceptAsync(consumer(promise, orElse), executor);
+    }
+
+    private Consumer<TaskContext.Value<T>> consumer(TaskContext.Promise<T> promise, Runnable orElse) {
+      return (lookupValue) -> {
+        lookupValue.consume((value) -> {
+//          logging.foundValue(task.id(), value);
+          promise.set(value);
+        });
+        lookupValue.onFail((ˍ) -> orElse.run());
+      };
+    }
+
+    private BiFunction<Response<ByteString>, Throwable, TaskContext.Value<T>> parseExisting(
+        Function<ByteString, T> decoder) {
+      return (response, throwable) -> {
+        final TaskContext.Promise<T> promise = promise();
+
+        if (throwable != null) {
+          promise.fail(throwable);
+        } else if (response.status().code() != Status.OK.code()) {
+          promise.fail(new RuntimeException("Not OK"));
+        } else if (!response.payload().isPresent()) {
+          promise.fail(new RuntimeException("Response with no body returned for persisted value from flock"));
+        } else {
+          final ByteString data = response.payload().get();
+          final T value = decoder.apply(data);
+          promise.set(value);
+        }
+
+        return promise.value();
+      };
+    }
+  }
+
+  private final class ProcessBundle<T> {
+
+    private final EvalBundle<T> evalBundle;
+    private final LockHolder lockHolder;
+    private final Fn<TaskContext.Value<T>> processFn;
+    private final TaskContext.Promise<T> promise;
+
+    private final Semaphore notified = new Semaphore(1);
+
+    public ProcessBundle(
+        EvalBundle<T> evalBundle,
+        LockHolder lockHolder,
+        Fn<TaskContext.Value<T>> processFn,
+        TaskContext.Promise<T> promise) {
+      this.evalBundle = evalBundle;
+      this.lockHolder = lockHolder;
+      this.processFn = processFn;
+      this.promise = promise;
+    }
+
+    private void process() {
+      Consumer<Throwable> whenLocked = onExecutor((throwable) -> {
+        final TaskId taskId = evalBundle.task.id();
+
+        if (throwable != null) {
+          if (throwable instanceof LockHolder.AlreadyLocked) {
+            if (notified.tryAcquire()) {
+//              logging.waiting(taskId);
+            }
+
+            evalBundle.fetchOrElse(promise, () -> scheduler.schedule(onExecutor(() -> {
+//              logging.polling(taskId);
+              process();
+            }), 1, TimeUnit.SECONDS)); // todo: already locked: wait without polling
+          } else {
+//            logging.lockFailed(taskId, throwable);
+            promise.fail(throwable);
+          }
+          return;
+        }
+
+        invoke();
+      });
+
+      if (shouldLock()) {
+        lockHolder.lock(whenLocked);
+      } else {
+        invoke();
+      }
+    }
+
+    private void invoke() {
+      TaskId taskId = evalBundle.task.id();
+      final TaskContext.Value<T> value = processFn.get();
+
+      value.consume((v) -> {
+        complete(
+            v,
+            () -> {
+//              logging.completedValue(taskId, v);
+              promise.set(v);
+            }, (t) -> {
+//              logging.failedValue(taskId, t);
+              promise.fail(t);
+            });
+      });
+      value.onFail((valueError) -> {
+//        logging.failedValue(taskId, valueError);
+        fail(() -> promise.fail(valueError));
+      });
+    }
+
+    private void complete(T value, Runnable callback, Consumer<Throwable> failure) {
+      if (shouldLock()) {
+        final Optional<ByteString> encoded;
+        try {
+          encoded = findEncoder(evalBundle.task.type()).map(fn -> fn.apply(value));
+        } catch (Throwable t) {
+          lockHolder.unlock(() -> failure.accept(t));
+          return;
+        }
+
+        if (encoded.isPresent()) {
+          lockHolder.unlock(encoded.get(), onExecutor(callback));
+        } else {
+          lockHolder.unlock(onExecutor(callback));
+        }
+      } else {
+        callback.run();
+      }
+    }
+
+    private void fail(Runnable callback) {
+      if (shouldLock()) {
+        lockHolder.unlock(onExecutor(callback));
+      } else {
+        callback.run();
+      }
+    }
+
+    private boolean shouldLock() {
+      return evalBundle.decoder.isPresent();
+    }
+  }
+}

--- a/test/src/main/java/io/rouz/scratch/persist/Encoder.java
+++ b/test/src/main/java/io/rouz/scratch/persist/Encoder.java
@@ -1,0 +1,18 @@
+package io.rouz.scratch.persist;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * TODO: document.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Encoder {
+
+  int ttl() default 30;
+  ChronoUnit unit() default ChronoUnit.SECONDS;
+}

--- a/test/src/main/java/io/rouz/scratch/persist/LockHolder.java
+++ b/test/src/main/java/io/rouz/scratch/persist/LockHolder.java
@@ -1,0 +1,133 @@
+package io.rouz.scratch.persist;
+
+import com.spotify.apollo.Client;
+import com.spotify.apollo.Request;
+import com.spotify.apollo.Status;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import io.rouz.flo.TaskId;
+import okio.ByteString;
+
+/**
+ * TODO: document.
+ */
+class LockHolder {
+
+  private static final int RENEW_INTERVAL = 10;
+
+  private final TaskId id;
+  private final String request;
+  private final ScheduledExecutorService scheduler;
+
+  private final Client client = r -> CompletableFuture.completedFuture(null);
+
+  private volatile boolean done = false;
+  private volatile ScheduledFuture<?> schedule;
+
+  LockHolder(
+      TaskId id,
+      String request,
+      ScheduledExecutorService scheduler) {
+    this.id = Objects.requireNonNull(id);
+    this.request = Objects.requireNonNull(request);
+    this.scheduler = Objects.requireNonNull(scheduler);
+  }
+
+  void lock(Consumer<Throwable> whenLocked) {
+    final Request lockRequest = Request.forUri(request, "POST")
+        .withPayload(Dump.json(id));
+
+    client.send(lockRequest)
+        .whenComplete((response, throwable) -> {
+
+          // todo: fix error handling (exception or already locked)
+
+          if (throwable != null) {
+            whenLocked.accept(throwable);
+            return;
+          }
+
+          if (response.status().code() == Status.CONFLICT.code()) {
+            whenLocked.accept(new AlreadyLocked());
+            return;
+          }
+
+          if (response.status().code() != Status.OK.code()) {
+            whenLocked.accept(new IllegalStateException(String.format(
+                "Could not lock %s - %s %s",
+                id, response.status().code(), response.status().reasonPhrase())));
+            return;
+          }
+
+//          logging.locked(id, response.payload().get().utf8());
+          schedule();
+
+          // successfully locked, null exception
+          whenLocked.accept(null);
+        });
+  }
+
+  void unlock(Runnable whenUnlocked) {
+    final Request deleteRequest = Request.forUri(request, "DELETE")
+        .withPayload(Dump.json(id));
+
+    unlock(deleteRequest, whenUnlocked);
+  }
+
+  void unlock(ByteString data, Runnable whenUnlocked) {
+    final Request deleteRequest = Request.forUri(request, "DELETE")
+        .withPayload(Dump.json(id, data));
+
+    unlock(deleteRequest, whenUnlocked);
+  }
+
+  private void unlock(Request deleteRequest, Runnable whenUnlocked) {
+//    logging.unlock(id);
+    done = true;
+    if (schedule != null) {
+      schedule.cancel(false);
+    }
+
+    client.send(deleteRequest) // todo: validate unlock
+        .thenAccept((reply) -> whenUnlocked.run());
+  }
+
+  private void schedule() {
+    schedule = scheduler.schedule(this::renew, RENEW_INTERVAL, TimeUnit.SECONDS);
+  }
+
+  private void renew() {
+    if (done) {
+      return;
+    }
+
+    final Request renewRequest = Request.forUri(request, "PUT")
+        .withPayload(Dump.json(id));
+
+//    logging.renewLock(id);
+    client.send(renewRequest)
+        .whenComplete((response, throwable) -> {
+          if (throwable != null) {
+            throwable.printStackTrace();
+            return;
+          }
+
+          if (response.status().code() != Status.OK.code()) {
+//            logging.renewFailed(id, response.status());
+          } else {
+//            logging.renewSuccess(id, response.payload().get().utf8());
+          }
+
+          schedule();
+        });
+  }
+
+  static class AlreadyLocked extends Exception {
+  }
+}

--- a/workflow/pom.xml
+++ b/workflow/pom.xml
@@ -19,6 +19,10 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.sf.jopt-simple</groupId>
             <artifactId>jopt-simple</artifactId>
         </dependency>

--- a/workflow/src/main/java/io/rouz/flo/TaskContext.java
+++ b/workflow/src/main/java/io/rouz/flo/TaskContext.java
@@ -6,7 +6,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collector;
@@ -36,7 +36,23 @@ public interface TaskContext {
    * @return A value of the task result
    */
   default <T> Value<T> evaluate(Task<T> task) {
-    return task.code().eval(this);
+    return evaluateInternal(task, this);
+  }
+
+  /**
+   * A variant of {@link #evaluate(Task)} that allows the caller to specify the {@link TaskContext}
+   * that should be used within the graph during evaluation.
+   *
+   * This is intended to be called from {@link TaskContext} implementations that form a composition
+   * of other contexts.
+   *
+   * @param task     The task to evaluate
+   * @param context  The context to use in further evaluation
+   * @param <T>      The type of the task result
+   * @return A value of the task result
+   */
+  default <T> Value<T> evaluateInternal(Task<T> task, TaskContext context) {
+    return task.code().eval(context);
   }
 
   /**
@@ -225,12 +241,12 @@ public interface TaskContext {
 
   /**
    * Create an asynchronous {@link TaskContext} that executes all evaluation on the given
-   * {@link ExecutorService}.
+   * {@link Executor}.
    *
-   * @param executorService  The executor service to run evaluations on
+   * @param executor  The executor to run evaluations on
    * @return The asynchronous context
    */
-  static TaskContext async(ExecutorService executorService) {
-    return AsyncContext.create(executorService);
+  static TaskContext async(Executor executor) {
+    return AsyncContext.create(executor);
   }
 }

--- a/workflow/src/main/java/io/rouz/flo/TaskContextWithId.java
+++ b/workflow/src/main/java/io/rouz/flo/TaskContextWithId.java
@@ -36,6 +36,11 @@ class TaskContextWithId implements TaskContext {
   }
 
   @Override
+  public <T> Value<T> evaluateInternal(Task<T> task, TaskContext context) {
+    return delegate.evaluateInternal(task, context);
+  }
+
+  @Override
   public <T> Value<T> invokeProcessFn(TaskId taskId, Fn<Value<T>> processFn) {
     return delegate.invokeProcessFn(taskId, processFn);
   }

--- a/workflow/src/main/java/io/rouz/flo/context/AsyncContext.java
+++ b/workflow/src/main/java/io/rouz/flo/context/AsyncContext.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -21,19 +22,19 @@ import io.rouz.flo.TaskContext;
  */
 public class AsyncContext implements TaskContext {
 
-  private final ExecutorService executor;
+  private final Executor executor;
 
-  protected AsyncContext(ExecutorService executor) {
+  protected AsyncContext(Executor executor) {
     this.executor = Objects.requireNonNull(executor);
   }
 
-  public static TaskContext create(ExecutorService executor) {
+  public static TaskContext create(Executor executor) {
     return new AsyncContext(executor);
   }
 
   @Override
-  public <T> Value<T> evaluate(Task<T> task) {
-    return flatten(() -> TaskContext.super.evaluate(task));
+  public <T> Value<T> evaluateInternal(Task<T> task, TaskContext context) {
+    return flatten(() -> TaskContext.super.evaluateInternal(task, context));
   }
 
   @Override

--- a/workflow/src/main/java/io/rouz/flo/context/InMemImmediateContext.java
+++ b/workflow/src/main/java/io/rouz/flo/context/InMemImmediateContext.java
@@ -33,7 +33,7 @@ public class InMemImmediateContext implements TaskContext {
   }
 
   @Override
-  public <T> Value<T> evaluate(Task<T> task) {
+  public <T> Value<T> evaluateInternal(Task<T> task, TaskContext context) {
     final TaskId taskId =  task.id();
 
     final Value<T> value;
@@ -41,7 +41,7 @@ public class InMemImmediateContext implements TaskContext {
       value = get(taskId);
       LOG.debug("Found calculated value for {} = {}", taskId, value);
     } else {
-      value = TaskContext.super.evaluate(task);
+      value = TaskContext.super.evaluateInternal(task, context);
       put(taskId, value);
     }
 

--- a/workflow/src/main/java/io/rouz/flo/context/MemoizingContext.java
+++ b/workflow/src/main/java/io/rouz/flo/context/MemoizingContext.java
@@ -1,0 +1,306 @@
+package io.rouz.flo.context;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+
+import io.rouz.flo.Fn;
+import io.rouz.flo.Task;
+import io.rouz.flo.TaskContext;
+import io.rouz.flo.TaskId;
+
+/**
+ * <p>A flo {@link TaskContext} that allows task types to define custom memoization strategies.
+ *
+ * <p>This context can be used to extend the {@link TaskContext#evaluate(Task)} algorithm with
+ * memoization behaviours specific to the {@link Task#type()}. This is specially useful when a
+ * type is backed by a an out-of-process store of some sort (database, service, etc).
+ *
+ * <p>By returning a value from {@link Memoizer#lookup(Task)}, this context will stop further
+ * evaluation of that tasks upstreams and short-circuit the evaluation algorithm at that task node.
+ * The resolved value will be used as input to dependent tasks
+ *
+ * <p>Example
+ *
+ * <pre>
+ *   Tasks a, b and c depend on each other in a chain: a -> b -> c.
+ *   // a depends on b, b depends on c
+ *
+ *   When calling context.evaluate(a), this will be the sequence of calls made:
+ *   context.evaluate(a)
+ *   aMemoizer.lookup(a) => empty()
+ *   context.evaluate(b)
+ *   bMemoizer.lookup(b) => empty()
+ *   context.evaluate(c)
+ *   cMemoizer.lookup(c) => empty()
+ *   cValue = context.invokeProcessFn(c, c.fn)
+ *   cMemoizer.store(c, cValue)
+ *   bValue = context.invokeProcessFn(b, b.fn)
+ *   bMemoizer.store(b, bValue)
+ *   aValue = context.invokeProcessFn(a, a.fn)
+ *   aMemoizer.store(a, aValue)
+ *
+ *   However, if any of the lookup calls return a value, the evaluation will short-circuit:
+ *   context.evaluate(a)
+ *   aMemoizer.lookup(a) => empty()
+ *   context.evaluate(b)
+ *   bMemoizer.lookup(b) => 'foo'
+ *   // no more expansion of upstreams to b
+ *   aValue = context.invokeProcessFn(a, a.fn)
+ *   aMemoizer.store(a, aValue)
+ * </pre>
+ *
+ * <p>{@link Memoizer} implementations are discovered through the {@link Memoizer.Impl} annotations
+ * on a static method on the task type that should have the signature
+ * {@code public static Memoizer<T> memoizer()}. The {@link Memoizer} type argument there should
+ * match the memoized type itself.
+ */
+public class MemoizingContext implements TaskContext {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MemoizingContext.class);
+
+  public interface Memoizer<T> {
+
+    /**
+     * Marks a method with signature {@code public static Memoizer<T> memoizer()}.
+     *
+     * Can be called multiple times during an evaluation. The memoizer instance must not itself
+     * contain the memoizing context, but rather use an internal registry or store to keep track
+     * of stored values.
+     */
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Impl { }
+
+    /**
+     * Lookup a memoized value for a given task.
+     *
+     * @param task  The task for which the lookup is made
+     * @return An optional memoized value for the task
+     */
+    Optional<T> lookup(Task task);
+
+    /**
+     * Store an evaluated value for a given task.
+     *
+     * @param task   The task for which the value was produced
+     * @param value  The value that was produced
+     */
+    void store(Task task, T value);
+
+    /**
+     * A memoizer that does nothing and always returns empty {@link #lookup} values
+     */
+    static <T> Memoizer<T> noop() {
+      //noinspection unchecked
+      return (Memoizer<T>) NOOP;
+    }
+  }
+
+  private static final Memoizer<Object> NOOP = new Memoizer<Object>() {
+
+    @Override
+    public Optional<Object> lookup(Task task) {
+      return Optional.empty();
+    }
+
+    @Override
+    public void store(Task task, Object value) {
+    }
+  };
+
+  private final TaskContext baseContext;
+  private final ImmutableMap<Class<?>, Memoizer<?>> memoizers;
+  private final ConcurrentMap<TaskId, EvalBundle<?>> ongoing = Maps.newConcurrentMap();
+
+  private MemoizingContext(TaskContext baseContext, ImmutableMap<Class<?>, Memoizer<?>> memoizers) {
+    this.baseContext = Objects.requireNonNull(baseContext);
+    this.memoizers = Objects.requireNonNull(memoizers);
+  }
+
+  public static TaskContext composeWith(TaskContext baseContext) {
+    return builder(baseContext).build();
+  }
+
+  public static Builder builder(TaskContext baseContext) {
+    return new Builder(baseContext);
+  }
+
+  public static class Builder {
+
+    private final TaskContext baseContext;
+    private final ImmutableMap.Builder<Class<?>, Memoizer<?>> memoizers = ImmutableMap.builder();
+
+    public Builder(TaskContext baseContext) {
+      this.baseContext = Objects.requireNonNull(baseContext);
+    }
+
+    /**
+     * Add an explicit memoizer for some type
+     */
+    public <T> Builder memoizer(Memoizer<T> memoizer) {
+      mapMemoizer(memoizer);
+      return this;
+    }
+
+    public TaskContext build() {
+      return new MemoizingContext(baseContext, memoizers.build());
+    }
+
+    private void mapMemoizer(Memoizer<?> memoizer) {
+      for (Type iface : memoizer.getClass().getGenericInterfaces()) {
+        if (iface.getTypeName().contains(Memoizer.class.getTypeName())) {
+          final ParameterizedType paramType = (ParameterizedType) iface;
+          final Class<?> memoizedType = (Class<?>) paramType.getActualTypeArguments()[0];
+          memoizers.put(memoizedType, memoizer);
+        }
+      }
+    }
+  }
+
+  @Override
+  public <T> Value<T> evaluateInternal(Task<T> task, TaskContext context) {
+    final EvalBundle<?> bundle = ongoing.computeIfAbsent(task.id(), createBundle(task, context));
+
+    bundle.evaluate();
+
+    //noinspection unchecked
+    return (Value<T>) bundle.promise.value();
+  }
+
+  private <T> Function<TaskId, EvalBundle<T>> createBundle(Task<T> task, TaskContext context) {
+    return (ˍ) -> {
+      final Memoizer<T> memoizer = findMemoizer(task.type()).orElse(Memoizer.noop());
+      return new EvalBundle<>(task, context, memoizer);
+    };
+  }
+
+  @Override
+  public <T> Value<T> invokeProcessFn(TaskId taskId, Fn<Value<T>> processFn) {
+    final EvalBundle<T> evalBundle = lookupBundle(taskId);
+    final Task<T> task = evalBundle.task;
+    final Memoizer<T> memoizer = evalBundle.memoizer;
+
+    final Value<T> tValue = baseContext.invokeProcessFn(taskId, processFn);
+    tValue.consume(v -> memoizer.store(task, v));
+
+    return tValue;
+  }
+
+  @Override
+  public <T> Value<T> value(Fn<T> value) {
+    return baseContext.value(value);
+  }
+
+  @Override
+  public <T> Promise<T> promise() {
+    return baseContext.promise();
+  }
+
+  /**
+   * Lookup existing promise for a given {@link TaskId}.
+   *
+   * Assumes that the promise either exist or will exist very shortly. The lookup will spin on
+   * the map until the promise shows up.
+   *
+   * This method is needed to overcome a race between the events:
+   * 1. task evaluation is asynchronously started
+   * 2. the designated promise is put into the map
+   * 3. the task process function being invoked
+   *
+   * Step 2 and 3 can happen in any order.
+   *
+   * See {@link #createBundle(Task, TaskContext)} and {@link #invokeProcessFn(TaskId, Fn)}.
+   *
+   * @param taskId  Task id for which to lookup
+   * @param <T>     The promise type
+   * @return The promise corresponding to the task id
+   */
+  private <T> EvalBundle<T> lookupBundle(TaskId taskId) {
+    EvalBundle<T> spin;
+    do {
+      //noinspection unchecked
+      spin = (EvalBundle<T>) ongoing.get(taskId);
+    } while (spin == null);
+    return spin;
+  }
+
+  private <T> Optional<Memoizer<T>> findMemoizer(Class<T> type) {
+    //noinspection unchecked
+    final Optional<Memoizer<T>> tMemoizer = Optional.ofNullable((Memoizer<T>) memoizers.get(type));
+
+    return Optional.ofNullable(tMemoizer.orElseGet(() -> {
+      for (Method method : type.getDeclaredMethods()) {
+        if (method.getDeclaredAnnotation(Memoizer.Impl.class) != null) {
+          //noinspection unchecked
+          return (Memoizer<T>) invokeAndPropagateException(method);
+        }
+      }
+      return null;
+    }));
+  }
+
+  private static Object invokeAndPropagateException(Method method, Object... args) {
+    try {
+      return method.invoke(/* static */ null, args);
+    } catch (IllegalAccessException | InvocationTargetException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  private static <T> void chain(Value<T> value, Promise<T> promise) {
+    value.consume(promise::set);
+    value.onFail(promise::fail);
+  }
+
+  private final class EvalBundle<T> {
+
+    private final Task<T> task;
+    private final Promise<T> promise;
+    private final TaskContext context;
+    private final Memoizer<T> memoizer;
+
+    private volatile boolean evaluated = false;
+
+    private EvalBundle(Task<T> task, TaskContext context, Memoizer<T> memoizer) {
+      this.task = task;
+      this.context = context;
+      this.memoizer = memoizer;
+
+      this.promise = context.promise();
+    }
+
+    synchronized void evaluate() {
+      if (evaluated) {
+        return;
+      }
+      evaluated = true;
+
+      final Optional<T> lookup = memoizer.lookup(task);
+      if (lookup.isPresent()) {
+        final T t = lookup.get();
+        LOG.debug("Not expanding {}, lookup = {}", task.id(), t);
+        promise.set(t);
+      } else {
+        LOG.debug("Expanding {}", task.id());
+        chain(baseContext.evaluateInternal(task, context), promise);
+      }
+    }
+  }
+}

--- a/workflow/src/test/java/io/rouz/flo/context/MemoizingContextTest.java
+++ b/workflow/src/test/java/io/rouz/flo/context/MemoizingContextTest.java
@@ -1,0 +1,128 @@
+package io.rouz.flo.context;
+
+import com.google.auto.value.AutoValue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import io.rouz.flo.AwaitingConsumer;
+import io.rouz.flo.Task;
+import io.rouz.flo.TaskContext;
+
+import static io.rouz.flo.TaskContext.inmem;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class MemoizingContextTest {
+
+  static ExampleValue value;
+  static MemoizingContext.Memoizer<ExampleValue> memoizer;
+
+  TaskContext context = MemoizingContext.composeWith(inmem());
+
+  int countUpstreamRuns = 0;
+  int countExampleRuns = 0;
+
+  @Before
+  public void setUp() throws Exception {
+    value = null;
+    memoizer = new ExampleValueMemoizer();
+  }
+
+  @Test
+  public void evaluatesAndStores() throws Exception {
+    Task<ExampleValue> example = example(7);
+
+    AwaitingConsumer<ExampleValue> await = new AwaitingConsumer<>();
+    context.evaluate(example).consume(await);
+
+    ExampleValue evaluatedValue = await.awaitAndGet();
+    assertThat(evaluatedValue, is(val("ups7", 7)));
+    assertThat(countUpstreamRuns, is(1));
+    assertThat(countExampleRuns, is(1));
+    assertThat(value, is(val("ups7", 7)));
+  }
+
+  @Test
+  public void evaluatesAndStoresWithExplicitMemoizer() throws Exception {
+    context = MemoizingContext.builder(inmem())
+        .memoizer(memoizer)
+        .build();
+
+    Task<ExampleValue> example = example(7);
+
+    AwaitingConsumer<ExampleValue> await = new AwaitingConsumer<>();
+    context.evaluate(example).consume(await);
+
+    ExampleValue evaluatedValue = await.awaitAndGet();
+    assertThat(evaluatedValue, is(val("ups7", 7)));
+    assertThat(countUpstreamRuns, is(1));
+    assertThat(countExampleRuns, is(1));
+    assertThat(value, is(val("ups7", 7)));
+  }
+
+  @Test
+  public void shortsEvaluationIfMemoizedValueExists() throws Exception {
+    value = val("ups8", 8);
+
+    Task<ExampleValue> example = example(8);
+
+    AwaitingConsumer<ExampleValue> await = new AwaitingConsumer<>();
+    context.evaluate(example).consume(await);
+
+    ExampleValue evaluatedValue = await.awaitAndGet();
+    assertThat(evaluatedValue, is(val("ups8", 8)));
+    assertThat(countUpstreamRuns, is(0));
+    assertThat(countExampleRuns, is(0));
+  }
+
+  Task<String> upstream(int i ) {
+    return Task.named("upstream", i).ofType(String.class)
+        .process(() -> {
+          countUpstreamRuns++;
+          return "ups" + i;
+        });
+  }
+
+  Task<ExampleValue> example(int i) {
+    return Task.named("example", i).ofType(ExampleValue.class)
+        .in(() -> upstream(i))
+        .in(() -> upstream(i))
+        .process((ups, ups1) -> {
+          countExampleRuns++;
+          return val(ups, i);
+        });
+  }
+
+  @AutoValue
+  public abstract static class ExampleValue {
+    abstract String foo();
+    abstract int bar();
+
+    @MemoizingContext.Memoizer.Impl
+    public static MemoizingContext.Memoizer<ExampleValue> memoizer() {
+      return memoizer;
+    }
+  }
+
+  static ExampleValue val(String foo, int bar) {
+    return new AutoValue_MemoizingContextTest_ExampleValue(foo, bar);
+  }
+
+  static class ExampleValueMemoizer implements MemoizingContext.Memoizer<ExampleValue> {
+
+    @Override
+    public Optional<ExampleValue> lookup(Task task) {
+      System.out.println("lookup task " + task.id());
+      return Optional.ofNullable(MemoizingContextTest.value);
+    }
+
+    @Override
+    public void store(Task task, ExampleValue value) {
+      System.out.println("store task " + task.id() + " value = " + value);
+      MemoizingContextTest.value = value;
+    }
+  }
+}


### PR DESCRIPTION
A memoization strategy for a given type can be implemented as:

```java
class ExampleValueMemoizer implements MemoizingContext.Memoizer<ExampleValue> {

  @Override
  public Optional<ExampleValue> lookup(Task task) {
    // lookup
  }

  @Override
  public void store(Task task, ExampleValue value) {
    // store
  }
}
```

To make the `Memoizer<T>` discoverable, annotate a constructor method on the memoized type:

```java
class ExampleValue {

  // fields ...

  @MemoizingContext.Memoizer.Impl
  public static MemoizingContext.Memoizer<ExampleValue> memoizer() {
    return new ExampleValueMemoizer();
  }
}
```

This `Memoizer<ExampleValue>` will apply to all `ExampleValue` tasks

```java
Task<ExampleValue> example() { /* ... */ }
```

that are evaluated within a `MemoizingContext`.

A Memoizing context can be created by composing it with another, more basic context:

```java
TaskContext context = MemoizingContext.composeWith(TaskContext.inmem());
```