### PR TITLE
Add InstrumentedContext

### DIFF
--- a/workflow/src/main/java/io/rouz/flo/context/InMemImmediateContext.java
+++ b/workflow/src/main/java/io/rouz/flo/context/InMemImmediateContext.java
@@ -50,7 +50,15 @@ public class InMemImmediateContext implements TaskContext {
 
   @Override
   public <T> Value<T> value(Fn<T> value) {
-    return new DirectValue<>(value.get());
+    final Promise<T> promise = promise();
+
+    try {
+      promise.set(value.get());
+    } catch (Throwable t) {
+      promise.fail(t);
+    }
+
+    return promise.value();
   }
 
   @Override

--- a/workflow/src/main/java/io/rouz/flo/context/InstrumentedContext.java
+++ b/workflow/src/main/java/io/rouz/flo/context/InstrumentedContext.java
@@ -1,0 +1,118 @@
+package io.rouz.flo.context;
+
+import java.util.Objects;
+
+import io.rouz.flo.Fn;
+import io.rouz.flo.Task;
+import io.rouz.flo.TaskContext;
+import io.rouz.flo.TaskId;
+
+/**
+ * A {@link TaskContext} that instruments the task expansion and invocation process.
+ *
+ * <p>This context will invoke methods on a {@link Listener} when tasks are evaluated through the
+ * {@link #evaluate(Task)} method.
+ *
+ * <p>The {@link Listener#edge(TaskId, TaskId)} method is called for each discovered
+ * upstream-downstream relation between two tasks that are about to be evaluated. This call is
+ * always made before the upstream is evaluated.
+ *
+ * <p>The {@link Listener#status(TaskId, Listener.Phase)} method is called when a task is actually
+ * being processed, i.e. when the {@link #invokeProcessFn(TaskId, Fn)} of that task in called in
+ * the {@link TaskContext}. There will be at most two calls made for
+ * each task. First with {@link Listener.Phase#START}, when evaluation starts. Then with either
+ * {@link Listener.Phase#SUCCESS} or {@link Listener.Phase#FAILURE} depending on the success or
+ * failure of the task {@link TaskContext.Value}.
+ *
+ */
+public class InstrumentedContext implements TaskContext {
+
+  /**
+   * A listener for instrumented evaluation. See {@link InstrumentedContext} for more details.
+   */
+  public interface Listener {
+
+    /**
+     * Called when an edge (dependency) between two tasks are discovered. The relation is that
+     * the downstream task depends on the upstream task. Also that the upstream task has to be
+     * evaluated first, before the downstream task can be evaluated.
+     *
+     * @param upstream    The id of the upstream task
+     * @param downstream  The id of the downstream task
+     */
+    void edge(TaskId upstream, TaskId downstream);
+
+    /**
+     * Called when a task starts and finished it's evaluation. This will be called exactly twice
+     * per evaluation of a task.
+     *
+     * @param task   The task that is being evaluated
+     * @param phase  The phase of evaluation
+     */
+    void status(TaskId task, Phase phase);
+
+    /**
+     * The different phases of task evaluation.
+     */
+    enum Phase {
+      /**
+       * The task has started evaluating
+       */
+      START,
+
+      /**
+       * The task completed evaluating successfully
+       */
+      SUCCESS,
+
+      /**
+       * The task completed evaluating with a failure
+       */
+      FAILURE
+    }
+  }
+
+  private final TaskContext baseContext;
+  private final Listener listener;
+
+  public InstrumentedContext(TaskContext baseContext, Listener listener) {
+    this.baseContext = Objects.requireNonNull(baseContext);
+    this.listener = Objects.requireNonNull(listener);
+  }
+
+  public static TaskContext composeWith(TaskContext baseContext, Listener listener) {
+    return new InstrumentedContext(baseContext, listener);
+  }
+
+  @Override
+  public <T> Value<T> evaluateInternal(Task<T> task, TaskContext context) {
+    task.inputs().stream()
+        .map(Task::id)
+        .distinct()
+        .forEach(upstream -> listener.edge(upstream, task.id()));
+
+    return baseContext.evaluateInternal(task, context);
+  }
+
+  @Override
+  public <T> Value<T> invokeProcessFn(TaskId taskId, Fn<Value<T>> processFn) {
+    listener.status(taskId, Listener.Phase.START);
+
+    final Value<T> tValue = baseContext.invokeProcessFn(taskId, processFn);
+
+    tValue.consume(v -> listener.status(taskId, Listener.Phase.SUCCESS));
+    tValue.onFail(t -> listener.status(taskId, Listener.Phase.FAILURE));
+
+    return tValue;
+  }
+
+  @Override
+  public <T> Value<T> value(Fn<T> value) {
+    return baseContext.value(value);
+  }
+
+  @Override
+  public <T> Promise<T> promise() {
+    return baseContext.promise();
+  }
+}

--- a/workflow/src/test/java/io/rouz/flo/TaskEvalBehaviorTest.java
+++ b/workflow/src/test/java/io/rouz/flo/TaskEvalBehaviorTest.java
@@ -126,9 +126,9 @@ public class TaskEvalBehaviorTest {
     Fn<Task<Integer>> countSupplier = countConstructor();
 
     Task<Integer> sum = Task.named("Sum").ofType(Integer.class)
-        .in(countSupplier::get)
-        .in(countSupplier::get)
-        .in(countSupplier::get)
+        .in(countSupplier)
+        .in(countSupplier)
+        .in(countSupplier)
         .process((a, b, c) -> a + b + c);
 
     // dummy run
@@ -143,9 +143,9 @@ public class TaskEvalBehaviorTest {
     Fn<Task<Integer>> countSupplier = countConstructor();
 
     Task<Integer> sum = Task.named("Sum").ofType(Integer.class).curried()
-        .in(countSupplier::get)
-        .in(countSupplier::get)
-        .in(countSupplier::get)
+        .in(countSupplier)
+        .in(countSupplier)
+        .in(countSupplier)
         .process(a -> b -> c -> a + b + c);
 
     // dummy run
@@ -244,9 +244,9 @@ public class TaskEvalBehaviorTest {
     Fn<Task<Integer>> countSupplier = countConstructor();
 
     Task<Integer> sum = Task.named("Sum").ofType(Integer.class)
-        .in(countSupplier::get)
-        .in(countSupplier::get)
-        .in(countSupplier::get)
+        .in(countSupplier)
+        .in(countSupplier)
+        .in(countSupplier)
         .process((a, b, c) -> a + b + c);
 
     // pre fetch one

--- a/workflow/src/test/java/io/rouz/flo/context/InstrumentedContextTest.java
+++ b/workflow/src/test/java/io/rouz/flo/context/InstrumentedContextTest.java
@@ -1,0 +1,87 @@
+package io.rouz.flo.context;
+
+import com.google.common.collect.Lists;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import io.rouz.flo.Task;
+import io.rouz.flo.TaskContext;
+import io.rouz.flo.TaskId;
+
+import static io.rouz.flo.TaskContext.inmem;
+import static io.rouz.flo.context.InstrumentedContext.Listener.Phase.FAILURE;
+import static io.rouz.flo.context.InstrumentedContext.Listener.Phase.START;
+import static io.rouz.flo.context.InstrumentedContext.Listener.Phase.SUCCESS;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+
+public class InstrumentedContextTest {
+
+  InstrumentedContext.Listener listener = new InstrumentedContext.Listener() {
+    @Override
+    public void edge(TaskId upstream, TaskId downstream) {
+      calls.add("edge:" + upstream + ":" + downstream);
+    }
+
+    @Override
+    public void status(TaskId task, Phase phase) {
+      calls.add("status:" + task + ":" + phase);
+    }
+  };
+
+  List<String> calls = Lists.newArrayList();
+  TaskContext context = InstrumentedContext.composeWith(inmem(), listener);
+
+  @Test
+  public void callsListenerWithEdgesAndStatuses() throws Exception {
+    Task<Integer> task = example(7);
+    context.evaluate(task);
+
+    TaskId example7 = task.id();
+    TaskId upstream7 = upstream(7).id();
+    TaskId upstream8 = upstream(8).id();
+
+    assertThat(calls, contains(
+        "edge:" + upstream7 + ":" + example7,
+        "edge:" + upstream8 + ":" + example7,
+        "status:" + upstream8 + ":" + START,
+        "status:" + upstream8 + ":" + SUCCESS,
+        "status:" + upstream7 + ":" + START,
+        "status:" + upstream7 + ":" + SUCCESS,
+        "status:" + example7 + ":" + START,
+        "status:" + example7 + ":" + SUCCESS
+    ));
+  }
+
+  @Test
+  public void callsStatusForFailingTask() throws Exception {
+    Task<String> failing = failing();
+    context.evaluate(failing);
+
+    assertThat(calls, contains(
+        "status:" + failing.id() + ":" + START,
+        "status:" + failing.id() + ":" + FAILURE
+    ));
+  }
+
+  Task<String> upstream(int i) {
+    return Task.named("upstream", i).ofType(String.class)
+        .process(() -> "upstream" + i);
+  }
+
+  Task<Integer> example(int i) {
+    return Task.named("example", i).ofType(Integer.class)
+        .in(() -> upstream(i))
+        .in(() -> upstream(i+1))
+        .process((u1, u2) -> u1.length() + u2.length());
+  }
+
+  Task<String> failing() {
+    return Task.named("failing").ofType(String.class)
+        .process(() -> {
+          throw new RuntimeException("fail");
+        });
+  }
+}


### PR DESCRIPTION
This adds a context that will report details about the task evaluation to a `Listener`.

```java
interface Listener {

  /**
   * Called when an edge (dependency) between two tasks are discovered. The relation is that
   * the downstream task depends on the upstream task. Also that the upstream task has to be
   * evaluated first, before the downstream task can be evaluated.
   *
   * @param upstream    The id of the upstream task
   * @param downstream  The id of the downstream task
   */
  void edge(TaskId upstream, TaskId downstream);

  /**
   * Called when a task starts and finished it's evaluation. This will be called exactly twice
   * per evaluation of a task.
   *
   * @param task   The task that is being evaluated
   * @param phase  The phase of evaluation
   */
  void status(TaskId task, Phase phase);
}
```