### PR TITLE
Complete a task value only when all inputs have completed

### DIFF
--- a/flo-api-generator/src/main/resources/TaskBuilderImpl.mustache
+++ b/flo-api-generator/src/main/resources/TaskBuilderImpl.mustache
@@ -57,7 +57,7 @@ final class {{implClassName}} {
           taskId, type,
           leafEvalFn(tc -> {
             Value<A> aValue = tc.evaluate(aTaskSingleton.get());
-            return f1 -> aValue.flatMap(f1::apply);
+            return aValue.map(a -> f1 -> f1.apply(a));
           }));
     }
 
@@ -70,7 +70,7 @@ final class {{implClassName}} {
           leafEvalFn(tc -> {
             Value<List<A>> aListValue = aTasksSingleton.get()
                 .stream().map(tc::evaluate).collect(tc.toValueList());
-            return f1 -> aListValue.flatMap(f1::apply);
+            return aListValue.map(a -> f1 -> f1.apply(a));
           }));
     }
 
@@ -79,7 +79,7 @@ final class {{implClassName}} {
       return new BuilderCurried.BuilderC0<>(taskId, type);
     }
 
-    //@Override
+    @Override
     public CurriedTaskBuilder.TaskBuilderCV0<Z> curriedWithContext() {
       return new BuilderCurried.BuilderCV0<>(taskId, type);
     }
@@ -134,7 +134,7 @@ final class {{implClassName}} {
           taskId, type,
           evaluator.chain(tc -> {
             Value<{{nextArg}}> nextValue = tc.evaluate(nextTaskSingleton.get());
-            return f{{arityPlus}} -> ({{arguments}}) -> nextValue.flatMap(next -> f{{arityPlus}}.apply({{arguments}}, next));
+            return nextValue.map(next -> f{{arityPlus}} -> ({{arguments}}) -> f{{arityPlus}}.apply({{arguments}}, next));
           }));
     }
 
@@ -145,9 +145,9 @@ final class {{implClassName}} {
           lazyFlatten(inputs, lazyFlatten(nextTasksSingleton)),
           taskId, type,
           evaluator.chain(tc -> {
-            Value<List<{{nextArg}}>> nextListValue = nextTasksSingleton.get()
+            Value<List<{{nextArg}}>> nextValue = nextTasksSingleton.get()
                 .stream().map(tc::evaluate).collect(tc.toValueList());
-            return f{{arityPlus}} -> ({{arguments}}) -> nextListValue.flatMap(next -> f{{arityPlus}}.apply({{arguments}}, next));
+            return nextValue.map(next -> f{{arityPlus}} -> ({{arguments}}) -> f{{arityPlus}}.apply({{arguments}}, next));
           }));
     }
   }

--- a/flo-api-generator/src/main/resources/TaskBuilderImpl.mustache
+++ b/flo-api-generator/src/main/resources/TaskBuilderImpl.mustache
@@ -14,6 +14,7 @@ import static io.rouz.flo.BuilderUtils.lazyFlatten;
 import static io.rouz.flo.BuilderUtils.lazyList;
 import static io.rouz.flo.BuilderUtils.leafEvalFn;
 import static io.rouz.flo.TaskContextWithId.withId;
+import static io.rouz.flo.Values.toValueList;
 
 /**
  * Package local implementation of the {@link TaskBuilder} tree.
@@ -69,7 +70,7 @@ final class {{implClassName}} {
           taskId, type,
           leafEvalFn(tc -> {
             Value<List<A>> aListValue = aTasksSingleton.get()
-                .stream().map(tc::evaluate).collect(tc.toValueList());
+                .stream().map(tc::evaluate).collect(toValueList(tc));
             return aListValue.map(a -> f1 -> f1.apply(a));
           }));
     }
@@ -146,7 +147,7 @@ final class {{implClassName}} {
           taskId, type,
           evaluator.chain(tc -> {
             Value<List<{{nextArg}}>> nextValue = nextTasksSingleton.get()
-                .stream().map(tc::evaluate).collect(tc.toValueList());
+                .stream().map(tc::evaluate).collect(toValueList(tc));
             return nextValue.map(next -> f{{arityPlus}} -> ({{arguments}}) -> f{{arityPlus}}.apply({{arguments}}, next));
           }));
     }

--- a/workflow/chain.md
+++ b/workflow/chain.md
@@ -1,0 +1,73 @@
+flo-core
+========
+
+### Definitions
+
+- `t<x>` - a `Task` of type `x`
+- `fN` - a function of N arguments with type `(...n) -> z`
+- `[ … ]` - an evaluation within the `value<x>` "box" of a `task<x>`
+- `builderN` - the builder at N inputs, with internal reference
+
+### Builders
+
+Let's start by looking at a builder with one input.
+
+```
+builder1 = flo.task("foo").in(task<a>)
+```
+
+The above expression (or equivalent in the Java or Scala API) evaluates to a builder that
+internally has the following structure.
+
+```
+builder1 ─┐
+          └ ┌                  ┐
+task<a> ───>│ a -> f1 -> f1(a) │
+            └                  ┘
+```
+
+A builder for a task of one input, has a reference to the evaluation "box" for `task<a>`'s value
+`a`.
+
+The function `f1` (`a -> z`) a placeholder for the function given to `builder1.process(f1)` which
+finalizes the builder and produces a `task<z>`.
+
+When `task<z>` is evaluated, `f1` is called with `a` from the input task as soon as it has
+finished evaluating. This will produce a `value<z>` which contains the value returned by `f1`, or
+any exception thrown along the dependecy tree.
+
+If instead `builder1.in(task<b>)` is called, a `builder2` is returned, which chains onto the
+evaluation "box" from the first builder.
+
+```
+builder1 ─┐
+          └ ┌                  ┐
+task<a> ───>│ a -> f1 -> f1(a) │
+          ┌ └      ^           ┘
+builder2 ─┤        └──────┐
+          └ ┌             ╵             ┐
+task<b> ───>│ b -> f2 -> (a) -> f2(a,b) │
+            └                           ┘
+```
+
+_describe chaining_
+
+```
+builder1 ─┐
+          └ ┌                  ┐
+task<a> ───>│ a -> f1 -> f1(a) │
+          ┌ └      ^           ┘
+builder2 ─┤        └──────┐
+          └ ┌             ╵             ┐
+task<b> ───>│ b -> f2 -> (a) -> f2(a,b) │
+          ┌ └      ^                    ┘
+builder3 ─┤        └──────┐
+          └ ┌             ╵                 ┐
+task<c> ───>│ c -> f3 -> (a,b) -> f3(a,b,c) │
+          ┌ └      ^                        ┘
+          ┆        ┆
+builderN ─┤        └──────┐
+          └ ┌             ╵                             ┐
+task<n> ───>│ n -> fn -> (a,b,…,n-1) -> fn(a,b,…,n-1,n) │
+            └                                           ┘
+```

--- a/workflow/src/main/java/io/rouz/flo/BuilderCurried.java
+++ b/workflow/src/main/java/io/rouz/flo/BuilderCurried.java
@@ -51,7 +51,7 @@ class BuilderCurried {
           leafEval(
               taskId,
               tc -> aTasksSingleton.get()
-                  .stream().map(tc::evaluate).collect(tc.toValueList())));
+                  .stream().map(tc::evaluate).collect(Values.toValueList(tc))));
     }
   }
 
@@ -81,7 +81,7 @@ class BuilderCurried {
           leafValEval(
               taskId,
               tc -> aTasksSingleton.get()
-                  .stream().map(tc::evaluate).collect(tc.toValueList())));
+                  .stream().map(tc::evaluate).collect(Values.toValueList(tc))));
     }
   }
 
@@ -117,7 +117,7 @@ class BuilderCurried {
           taskId, type,
           evaluator.curry(
               tc -> bTasksSingleton.get()
-                  .stream().map(tc::evaluate).collect(tc.toValueList())));
+                  .stream().map(tc::evaluate).collect(Values.toValueList(tc))));
     }
   }
 
@@ -155,7 +155,7 @@ class BuilderCurried {
           taskId, type,
           evaluator.curry(
               tc -> bTasksSingleton.get()
-                  .stream().map(tc::evaluate).collect(tc.toValueList())));
+                  .stream().map(tc::evaluate).collect(Values.toValueList(tc))));
     }
   }
 

--- a/workflow/src/main/java/io/rouz/flo/BuilderUtils.java
+++ b/workflow/src/main/java/io/rouz/flo/BuilderUtils.java
@@ -2,7 +2,6 @@ package io.rouz.flo;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 import io.rouz.flo.TaskContext.Value;
@@ -74,7 +73,7 @@ class BuilderUtils {
         Value<Fn1<G, F>> gv = mapClosure.eval(tc);
         Value<Fn1<F, Value<Z>>> fv = fClosure.eval(tc);
 
-        return tc.mapBoth(gv, fv, (gc, fc) -> g -> fc.apply(gc.apply(g)));
+        return Values.mapBoth(tc, gv, fv, (gc, fc) -> g -> fc.apply(gc.apply(g)));
       };
       return new ChainingEval<>(continuation);
     }

--- a/workflow/src/main/java/io/rouz/flo/TaskContext.java
+++ b/workflow/src/main/java/io/rouz/flo/TaskContext.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executor;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collector;
@@ -122,6 +124,49 @@ public interface TaskContext {
    * @return A promise
    */
   <T> Promise<T> promise();
+
+  /**
+   * Maps a function over two {@link Value}s returning a new {@link Value} of the result which
+   * only becomes available when both inputs have completed.
+   *
+   * <p>The returned {@link Value} will not complete until both input values have completed either
+   * successfully or with an exception. If both inputs fail with an exception, the exception from
+   * {@code first} will be propagated into the returned value.
+   *
+   * @param first  The first input value
+   * @param second The second input value
+   * @param fn     The map function
+   * @param <T>    The type of the first input value
+   * @param <U>    The type of the second input value
+   * @param <V>    The type of the return value
+   * @return A value that completes only when both inputs have completed
+   */
+  default <T, U, V> Value<V> mapBoth(
+      Value<T> first,
+      Value<U> second,
+      BiFunction<? super T, ? super U, ? extends V> fn) {
+    Promise<V> promise = promise();
+
+    BiConsumer<T, Throwable> firstComplete = (t, firstThrowable) -> {
+      BiConsumer<U, Throwable> secondComplete = (v, secondThrowable) -> {
+        if (firstThrowable != null) {
+          promise.fail(firstThrowable);
+        } else if (secondThrowable != null) {
+          promise.fail(secondThrowable);
+        } else {
+          promise.set(fn.apply(t, v));
+        }
+      };
+
+      second.consume(v -> secondComplete.accept(v, null));
+      second.onFail(e -> secondComplete.accept(null, e));
+    };
+
+    first.consume(t -> firstComplete.accept(t, null));
+    first.onFail(e -> firstComplete.accept(null, e));
+
+    return promise.value();
+  }
 
   /**
    * A {@link Collector} that collects a {@link Stream} of {@link Value}s into a {@link Value}

--- a/workflow/src/main/java/io/rouz/flo/TaskContext.java
+++ b/workflow/src/main/java/io/rouz/flo/TaskContext.java
@@ -3,16 +3,10 @@ package io.rouz.flo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executor;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.stream.Collector;
-import java.util.stream.Stream;
 
 import io.rouz.flo.context.AsyncContext;
 import io.rouz.flo.context.InMemImmediateContext;
@@ -124,64 +118,6 @@ public interface TaskContext {
    * @return A promise
    */
   <T> Promise<T> promise();
-
-  /**
-   * Maps a function over two {@link Value}s returning a new {@link Value} of the result which
-   * only becomes available when both inputs have completed.
-   *
-   * <p>The returned {@link Value} will not complete until both input values have completed either
-   * successfully or with an exception. If both inputs fail with an exception, the exception from
-   * {@code first} will be propagated into the returned value.
-   *
-   * @param first  The first input value
-   * @param second The second input value
-   * @param fn     The map function
-   * @param <T>    The type of the first input value
-   * @param <U>    The type of the second input value
-   * @param <V>    The type of the return value
-   * @return A value that completes only when both inputs have completed
-   */
-  default <T, U, V> Value<V> mapBoth(
-      Value<T> first,
-      Value<U> second,
-      BiFunction<? super T, ? super U, ? extends V> fn) {
-    Promise<V> promise = promise();
-
-    BiConsumer<T, Throwable> firstComplete = (t, firstThrowable) -> {
-      BiConsumer<U, Throwable> secondComplete = (v, secondThrowable) -> {
-        if (firstThrowable != null) {
-          promise.fail(firstThrowable);
-        } else if (secondThrowable != null) {
-          promise.fail(secondThrowable);
-        } else {
-          promise.set(fn.apply(t, v));
-        }
-      };
-
-      second.consume(v -> secondComplete.accept(v, null));
-      second.onFail(e -> secondComplete.accept(null, e));
-    };
-
-    first.consume(t -> firstComplete.accept(t, null));
-    first.onFail(e -> firstComplete.accept(null, e));
-
-    return promise.value();
-  }
-
-  /**
-   * A {@link Collector} that collects a {@link Stream} of {@link Value}s into a {@link Value}
-   * of a {@link List}.
-   *
-   * <p>The semantics of joining {@link Value}s is decided by this {@link TaskContext}.
-   *
-   * @param <T>  The inner type of the values
-   * @return A collector for a stream of values
-   */
-  default <T> Collector<Value<T>, ?, Value<List<T>>> toValueList() {
-    return Collector.of(
-        ArrayList::new, List::add, (a,b) -> { a.addAll(b); return a; },
-        ValueFold.inContext(this));
-  }
 
   /**
    * A wrapped value with additional semantics for how the enclosed value becomes available and

--- a/workflow/src/main/java/io/rouz/flo/TaskContextWithId.java
+++ b/workflow/src/main/java/io/rouz/flo/TaskContextWithId.java
@@ -1,21 +1,20 @@
 package io.rouz.flo;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collector;
+
+import io.rouz.flo.context.ForwardingTaskContext;
 
 import static java.util.Objects.requireNonNull;
 
 /**
  * A {@link TaskContext} that overrides {@link #currentTaskId()} to return a specific {@link TaskId}.
  */
-class TaskContextWithId implements TaskContext {
+class TaskContextWithId extends ForwardingTaskContext {
 
-  private final TaskContext delegate;
   private final TaskId taskId;
 
   private TaskContextWithId(TaskContext delegate, TaskId taskId) {
-    this.delegate = requireNonNull(delegate);
+    super(delegate);
     this.taskId = requireNonNull(taskId);
   }
 
@@ -26,42 +25,5 @@ class TaskContextWithId implements TaskContext {
   @Override
   public Optional<TaskId> currentTaskId() {
     return Optional.of(taskId);
-  }
-
-  // === forwarding methods =======================================================================
-
-  @Override
-  public <T> Value<T> evaluate(Task<T> task) {
-    return delegate.evaluate(task);
-  }
-
-  @Override
-  public <T> Value<T> evaluateInternal(Task<T> task, TaskContext context) {
-    return delegate.evaluateInternal(task, context);
-  }
-
-  @Override
-  public <T> Value<T> invokeProcessFn(TaskId taskId, Fn<Value<T>> processFn) {
-    return delegate.invokeProcessFn(taskId, processFn);
-  }
-
-  @Override
-  public <T> Value<T> value(Fn<T> value) {
-    return delegate.value(value);
-  }
-
-  @Override
-  public <T> Value<T> immediateValue(T value) {
-    return delegate.immediateValue(value);
-  }
-
-  @Override
-  public <T> Promise<T> promise() {
-    return delegate.promise();
-  }
-
-  @Override
-  public <T> Collector<Value<T>, ?, Value<List<T>>> toValueList() {
-    return delegate.toValueList();
   }
 }

--- a/workflow/src/main/java/io/rouz/flo/ValueFold.java
+++ b/workflow/src/main/java/io/rouz/flo/ValueFold.java
@@ -30,7 +30,7 @@ final class ValueFold<T> implements Function<List<Value<T>>, Value<List<T>>> {
   public Value<List<T>> apply(List<Value<T>> list) {
     Value<List<T>> values = taskContext.immediateValue(new ArrayList<>());
     for (Value<T> tValue : list) {
-      values = taskContext.mapBoth(values, tValue, (l, t) -> {
+      values = Values.mapBoth(taskContext, values, tValue, (l, t) -> {
         l.add(t);
         return l;
       });

--- a/workflow/src/main/java/io/rouz/flo/ValueFold.java
+++ b/workflow/src/main/java/io/rouz/flo/ValueFold.java
@@ -30,13 +30,10 @@ final class ValueFold<T> implements Function<List<Value<T>>, Value<List<T>>> {
   public Value<List<T>> apply(List<Value<T>> list) {
     Value<List<T>> values = taskContext.immediateValue(new ArrayList<>());
     for (Value<T> tValue : list) {
-      values = values.flatMap(
-          l -> tValue.map(
-              t -> {
-                l.add(t);
-                return l;
-              }
-          ));
+      values = taskContext.mapBoth(values, tValue, (l, t) -> {
+        l.add(t);
+        return l;
+      });
     }
     return values;
   }

--- a/workflow/src/main/java/io/rouz/flo/Values.java
+++ b/workflow/src/main/java/io/rouz/flo/Values.java
@@ -1,0 +1,80 @@
+package io.rouz.flo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.stream.Collector;
+import java.util.stream.Stream;
+
+import io.rouz.flo.TaskContext.Value;
+
+/**
+ * Utilities for manipulating instances of {@link Value}.
+ */
+public final class Values {
+
+  private Values() {
+  }
+
+  /**
+   * Maps a function over two {@link Value}s returning a new {@link Value} of the result which
+   * only becomes available when both inputs have completed.
+   *
+   * <p>The returned {@link Value} will not complete until both input values have completed either
+   * successfully or with an exception. If both inputs fail with an exception, the exception from
+   * {@code first} will be propagated into the returned value.
+   *
+   * @param context The context which values are processed in
+   * @param first   The first input value
+   * @param second  The second input value
+   * @param fn      The map function
+   * @param <T>     The type of the first input value
+   * @param <U>     The type of the second input value
+   * @param <V>     The type of the return value
+   * @return A value that completes only when both inputs have completed
+   */
+  public static <T, U, V> Value<V> mapBoth(
+      TaskContext context,
+      Value<T> first,
+      Value<U> second,
+      BiFunction<? super T, ? super U, ? extends V> fn) {
+    TaskContext.Promise<V> promise = context.promise();
+
+    BiConsumer<T, Throwable> firstComplete = (t, firstThrowable) -> {
+      BiConsumer<U, Throwable> secondComplete = (v, secondThrowable) -> {
+        if (firstThrowable != null) {
+          promise.fail(firstThrowable);
+        } else if (secondThrowable != null) {
+          promise.fail(secondThrowable);
+        } else {
+          promise.set(fn.apply(t, v));
+        }
+      };
+
+      second.consume(v -> secondComplete.accept(v, null));
+      second.onFail(e -> secondComplete.accept(null, e));
+    };
+
+    first.consume(t -> firstComplete.accept(t, null));
+    first.onFail(e -> firstComplete.accept(null, e));
+
+    return promise.value();
+  }
+
+  /**
+   * A {@link Collector} that collects a {@link Stream} of {@link Value}s into a {@link Value}
+   * of a {@link List}.
+   *
+   * <p>The semantics of joining {@link Value}s is decided by this {@link TaskContext}.
+   *
+   * @param context The context which values are processed in
+   * @param <T>     The inner type of the values
+   * @return A collector for a stream of values
+   */
+  public static <T> Collector<Value<T>, ?, Value<List<T>>> toValueList(TaskContext context) {
+    return Collector.of(
+        ArrayList::new, List::add, (a, b) -> { a.addAll(b); return a; },
+        ValueFold.inContext(context));
+  }
+}

--- a/workflow/src/main/java/io/rouz/flo/context/ForwardingTaskContext.java
+++ b/workflow/src/main/java/io/rouz/flo/context/ForwardingTaskContext.java
@@ -1,0 +1,61 @@
+package io.rouz.flo.context;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.stream.Collector;
+
+import io.rouz.flo.Fn;
+import io.rouz.flo.Task;
+import io.rouz.flo.TaskContext;
+import io.rouz.flo.TaskId;
+
+/**
+ * A {@link TaskContext} that forwards calls.
+ */
+public abstract class ForwardingTaskContext implements TaskContext {
+
+  protected final TaskContext delegate;
+
+  protected ForwardingTaskContext(TaskContext delegate) {
+    this.delegate = Objects.requireNonNull(delegate);
+  }
+
+  @Override
+  public <T> Value<T> evaluateInternal(Task<T> task, TaskContext context) {
+    return delegate.evaluateInternal(task, context);
+  }
+
+  @Override
+  public <T> Value<T> invokeProcessFn(TaskId taskId, Fn<Value<T>> processFn) {
+    return delegate.invokeProcessFn(taskId, processFn);
+  }
+
+  @Override
+  public <T> Value<T> value(Fn<T> value) {
+    return delegate.value(value);
+  }
+
+  @Override
+  public <T> Value<T> immediateValue(T value) {
+    return delegate.immediateValue(value);
+  }
+
+  @Override
+  public <T> Promise<T> promise() {
+    return delegate.promise();
+  }
+
+  @Override
+  public <T, U, V> Value<V> mapBoth(
+      Value<T> first,
+      Value<U> second,
+      BiFunction<? super T, ? super U, ? extends V> fn) {
+    return delegate.mapBoth(first, second, fn);
+  }
+
+  @Override
+  public <T> Collector<Value<T>, ?, Value<List<T>>> toValueList() {
+    return delegate.toValueList();
+  }
+}

--- a/workflow/src/main/java/io/rouz/flo/context/ForwardingTaskContext.java
+++ b/workflow/src/main/java/io/rouz/flo/context/ForwardingTaskContext.java
@@ -1,9 +1,6 @@
 package io.rouz.flo.context;
 
-import java.util.List;
 import java.util.Objects;
-import java.util.function.BiFunction;
-import java.util.stream.Collector;
 
 import io.rouz.flo.Fn;
 import io.rouz.flo.Task;
@@ -44,18 +41,5 @@ public abstract class ForwardingTaskContext implements TaskContext {
   @Override
   public <T> Promise<T> promise() {
     return delegate.promise();
-  }
-
-  @Override
-  public <T, U, V> Value<V> mapBoth(
-      Value<T> first,
-      Value<U> second,
-      BiFunction<? super T, ? super U, ? extends V> fn) {
-    return delegate.mapBoth(first, second, fn);
-  }
-
-  @Override
-  public <T> Collector<Value<T>, ?, Value<List<T>>> toValueList() {
-    return delegate.toValueList();
   }
 }

--- a/workflow/src/main/java/io/rouz/flo/context/InMemImmediateContext.java
+++ b/workflow/src/main/java/io/rouz/flo/context/InMemImmediateContext.java
@@ -93,12 +93,6 @@ public class InMemImmediateContext implements TaskContext {
       this.setLatch = new Semaphore(1);
     }
 
-    private DirectValue(T value) {
-      valueReceiver = new AtomicReference<>(c -> c.accept(value));
-      failureReceiver = new AtomicReference<>(c -> {});
-      this.setLatch = new Semaphore(0);
-    }
-
     @Override
     public TaskContext context() {
       return InMemImmediateContext.this;

--- a/workflow/src/test/java/io/rouz/flo/AwaitingConsumer.java
+++ b/workflow/src/test/java/io/rouz/flo/AwaitingConsumer.java
@@ -26,8 +26,16 @@ public final class AwaitingConsumer<T> implements Consumer<T> {
     return latch.getCount() == 0;
   }
 
+  public boolean await() throws InterruptedException {
+    return await(1, TimeUnit.SECONDS);
+  }
+
+  public boolean await(long time, TimeUnit unit) throws InterruptedException {
+    return latch.await(time, unit);
+  }
+
   public T awaitAndGet() throws InterruptedException {
-    assertTrue("wait for value", latch.await(1, TimeUnit.SECONDS));
+    assertTrue("wait for value", await());
     return value;
   }
 

--- a/workflow/src/test/java/io/rouz/flo/ControlledBlockingContext.java
+++ b/workflow/src/test/java/io/rouz/flo/ControlledBlockingContext.java
@@ -187,9 +187,11 @@ class ControlledBlockingContext implements TaskContext {
       }
     }
 
+    /**
+     * Does nothing. Value can not fail, see {@link ValuePromise#fail(Throwable)}.
+     */
     @Override
     public void onFail(Consumer<Throwable> errorConsumer) {
-      throw new UnsupportedOperationException();
     }
 
     @Override

--- a/workflow/src/test/java/io/rouz/flo/InputSyncCompletionTest.java
+++ b/workflow/src/test/java/io/rouz/flo/InputSyncCompletionTest.java
@@ -1,0 +1,81 @@
+package io.rouz.flo;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class InputSyncCompletionTest {
+
+  TaskContext context = TaskContext.async(Executors.newFixedThreadPool(2));
+
+  AwaitingConsumer<TaskContext.Promise<Integer>> blocked = new AwaitingConsumer<>();
+  Task<Integer> blocking = Task.named("blocking").ofType(Integer.class)
+      .processWithContext((tc) -> {
+        TaskContext.Promise<Integer> promise = tc.promise();
+        blocked.accept(promise);
+        return promise.value();
+      });
+
+  Task<Integer> failing = Task.named("failing").ofType(Integer.class)
+      .process(() -> {
+        throw new RuntimeException("failed");
+      });
+
+  @Test
+  public void shouldNotCompleteTaskBeforeAllInputsAreDone_FailingBefore() throws Exception {
+    Task<String> task = Task.named("sync").ofType(String.class)
+        .in(() -> failing)
+        .in(() -> blocking)
+        .process((a, b) -> "should not happen");
+
+    awaitBlocked(task);
+  }
+
+  @Test
+  public void shouldNotCompleteTaskBeforeAllInputsAreDone_FailingAfter() throws Exception {
+    Task<String> task = Task.named("sync").ofType(String.class)
+        .in(() -> blocking)
+        .in(() -> failing)
+        .process((a, b) -> "should not happen");
+
+    awaitBlocked(task);
+  }
+
+  @Test
+  public void shouldNotCompleteTaskBeforeAllInputsAreDone_AsInputListBefore() throws Exception {
+    Task<String> task = Task.named("sync").ofType(String.class)
+        .ins(() -> Arrays.asList(failing, blocking))
+        .process(a -> "should not happen");
+
+    awaitBlocked(task);
+  }
+
+  @Test
+  public void shouldNotCompleteTaskBeforeAllInputsAreDone_AsInputListAfter() throws Exception {
+    Task<String> task = Task.named("sync").ofType(String.class)
+        .ins(() -> Arrays.asList(blocking, failing))
+        .process(a -> "should not happen");
+
+    awaitBlocked(task);
+  }
+
+  private void awaitBlocked(Task<String> task) throws InterruptedException {
+    AwaitingConsumer<Throwable> eval = new AwaitingConsumer<>();
+    context.evaluate(task).onFail(eval);
+
+    // should not complete before we unblock the blocked promise
+    assertThat(eval.await(1, TimeUnit.SECONDS), is(false));
+
+    blocked.awaitAndGet().set(42);
+    Throwable throwable = eval.awaitAndGet();
+
+    assertThat(throwable, instanceOf(RuntimeException.class));
+    assertThat(throwable.getMessage(), is("failed"));
+  }
+}

--- a/workflow/src/test/java/io/rouz/flo/TaskContextWithIdTest.java
+++ b/workflow/src/test/java/io/rouz/flo/TaskContextWithIdTest.java
@@ -3,17 +3,12 @@ package io.rouz.flo;
 import org.junit.Test;
 
 import java.util.Optional;
-import java.util.stream.Collector;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class TaskContextWithIdTest {
-
-  static final Task<String> TASK = Task.create(() -> "", String.class, "foo");
-  static final Fn<TaskContext.Value<Object>> FN = () -> null;
 
   TaskContext delegate = mock(TaskContext.class);
   TaskId taskId = TaskId.create("TestTAsk", "a", "b");
@@ -28,61 +23,5 @@ public class TaskContextWithIdTest {
   @Test
   public void testCurrentTaskId() throws Exception {
     assertThat(sut.currentTaskId(), is(Optional.of(taskId)));
-  }
-
-  @Test
-  public void testEvaluateDelegates() throws Exception {
-    //noinspection unchecked
-    TaskContext.Value<String> value = mock(TaskContext.Value.class);
-    when(delegate.evaluate(TASK)).thenReturn(value);
-
-    assertThat(sut.evaluate(TASK), is(value));
-  }
-
-  @Test
-  public void testInvokeProcessFnDelegates() throws Exception {
-    //noinspection unchecked
-    TaskContext.Value<Object> value = mock(TaskContext.Value.class);
-    when(delegate.invokeProcessFn(TASK.id(), FN)).thenReturn(value);
-
-    assertThat(sut.invokeProcessFn(TASK.id(), FN), is(value));
-  }
-
-  @Test
-  public void testValueDelegates() throws Exception {
-    //noinspection unchecked
-    TaskContext.Value<Object> value = mock(TaskContext.Value.class);
-    Fn<Object> fn = Object::new;
-    when(delegate.value(fn)).thenReturn(value);
-
-    sut.value(fn);
-  }
-
-  @Test
-  public void testImmediateValueDelegates() throws Exception {
-    //noinspection unchecked
-    TaskContext.Value<String> value = mock(TaskContext.Value.class);
-    when(delegate.immediateValue("STRING")).thenReturn(value);
-
-    assertThat(sut.immediateValue("STRING"), is(value));
-  }
-
-  @Test
-  public void testPromiseDelegates() throws Exception {
-    //noinspection unchecked
-    TaskContext.Promise<String> promise = mock(TaskContext.Promise.class);
-    when(delegate.<String>promise()).thenReturn(promise);
-
-    assertThat(sut.promise(), is(promise));
-  }
-
-  @Test
-  public void testToValueListDelegates() throws Exception {
-    Collector collector = TaskContext.inmem().toValueList();
-    //noinspection unchecked
-    when(delegate.toValueList()).thenReturn(collector);
-
-    // todo: this method does not really belong to the interface
-    assertThat(sut.toValueList(), is(collector));
   }
 }

--- a/workflow/src/test/java/io/rouz/flo/TaskEvalBehaviorTest.java
+++ b/workflow/src/test/java/io/rouz/flo/TaskEvalBehaviorTest.java
@@ -319,8 +319,6 @@ public class TaskEvalBehaviorTest {
     TaskId evenify1Id = evenify(1).id();
     TaskId evenify3Id = evenify(3).id();
 
-    System.out.println("taskIds = " + taskIds);
-
     assertThat(taskIds.size(), is(10));
     assertThat(taskIds, containsInOrder(evenify5Id, evenify1Id));
     assertThat(taskIds, containsInOrder(evenify5Id, evenify3Id));

--- a/workflow/src/test/java/io/rouz/flo/context/ForwardingTaskContextTest.java
+++ b/workflow/src/test/java/io/rouz/flo/context/ForwardingTaskContextTest.java
@@ -1,0 +1,71 @@
+package io.rouz.flo.context;
+
+import org.junit.Test;
+
+import io.rouz.flo.Fn;
+import io.rouz.flo.Task;
+import io.rouz.flo.TaskContext;
+import io.rouz.flo.TaskContext.Value;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ForwardingTaskContextTest {
+
+  static final Task<String> TASK = Task.create(() -> "", String.class, "test");
+
+  TaskContext delegate = mock(TaskContext.class);
+  TaskContext sut = new TestContext(delegate);
+
+  @Test
+  public void evaluate() throws Exception {
+    sut.evaluate(TASK);
+
+    verify(delegate).evaluateInternal(TASK, sut);
+  }
+
+  @Test
+  public void evaluateInternal() throws Exception {
+    sut.evaluateInternal(TASK, delegate);
+
+    verify(delegate).evaluateInternal(TASK, delegate);
+  }
+
+  @Test
+  public void invokeProcessFn() throws Exception {
+    Fn<Value<Object>> fn = () -> null;
+    sut.invokeProcessFn(TASK.id(), fn);
+
+    verify(delegate).invokeProcessFn(TASK.id(), fn);
+  }
+
+  @Test
+  public void value() throws Exception {
+    Fn<String> fn = () -> "";
+    sut.value(fn);
+
+    verify(delegate).value(fn);
+  }
+
+  @Test
+  public void immediateValue() throws Exception {
+    String value = "";
+    sut.immediateValue(value);
+
+    verify(delegate).immediateValue(value);
+  }
+
+  @Test
+  public void promise() throws Exception {
+    sut.promise();
+
+    verify(delegate).promise();
+  }
+
+  private static class TestContext extends ForwardingTaskContext {
+
+    TestContext(TaskContext delegate) {
+      super(delegate);
+    }
+  }
+}


### PR DESCRIPTION
The current behaviour is a bit unexpected in that it will fail an eval root as soon as any of the tasks in the tree throws an exception. This leads to any already active task to be left behind and ignored.

This patch fixes the behaviour so that a task value only completes once all of the input tasks have finished evaluating.