### PR TITLE
Add persisting and point-evaluating contexts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 .idea
+dependency-reduced-pom.xml
 *.iml

--- a/flo-freezer/pom.xml
+++ b/flo-freezer/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>flo</artifactId>
+    <groupId>io.rouz</groupId>
+    <version>0.0.10-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>flo-freezer</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.rouz</groupId>
+      <artifactId>flo-workflow</artifactId>
+      <version>0.0.10-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>com.esotericsoftware</groupId>
+      <artifactId>kryo-shaded</artifactId>
+      <version>4.0.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.fusesource.jansi</groupId>
+      <artifactId>jansi</artifactId>
+      <version>1.11</version>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/flo-freezer/pom.xml
+++ b/flo-freezer/pom.xml
@@ -24,12 +24,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.fusesource.jansi</groupId>
-      <artifactId>jansi</artifactId>
-      <version>1.11</version>
-    </dependency>
-
-    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>

--- a/flo-freezer/src/main/java/io/rouz/flo/freezer/EvaluatingContext.java
+++ b/flo-freezer/src/main/java/io/rouz/flo/freezer/EvaluatingContext.java
@@ -15,7 +15,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * TODO: document.
+ * A wrapper context that allows for evaluating specific tasks. This class is intended to be used
+ * in pairing with {@link PersistingContext}.
+ *
+ * <p>See {@link #evaluateTaskFrom(Path)}.
+ *
+ * <p>todo: support reading and writing from arbitrary {@link Path} types
  */
 public class EvaluatingContext {
 
@@ -29,6 +34,16 @@ public class EvaluatingContext {
     this.delegate = Objects.requireNonNull(delegate);
   }
 
+  /**
+   * Evaluate a persisted task, expecting it's input values to exist as "_out" files in the same
+   * directory.
+   *
+   * <p>The output of the evaluated task will be persisted in the same directory.
+   *
+   * @param persistedTask A path to the persisted task file that should be evaluated
+   * @param <T>           The task output type
+   * @return The task output value
+   */
   public <T> TaskContext.Value<T> evaluateTaskFrom(Path persistedTask) {
     Task<T> task = null;
     try {

--- a/flo-freezer/src/main/java/io/rouz/flo/freezer/EvaluatingContext.java
+++ b/flo-freezer/src/main/java/io/rouz/flo/freezer/EvaluatingContext.java
@@ -1,6 +1,6 @@
 package io.rouz.flo.freezer;
 
-import static io.rouz.flo.freezer.LoggingListener.colored;
+import static io.rouz.flo.Util.colored;
 import static io.rouz.flo.freezer.PersistingContext.cleanForFilename;
 
 import io.rouz.flo.Fn;

--- a/flo-freezer/src/main/java/io/rouz/flo/freezer/EvaluatingContext.java
+++ b/flo-freezer/src/main/java/io/rouz/flo/freezer/EvaluatingContext.java
@@ -1,0 +1,110 @@
+package io.rouz.flo.freezer;
+
+import static io.rouz.flo.freezer.LoggingListener.colored;
+import static io.rouz.flo.freezer.PersistingContext.cleanForFilename;
+
+import io.rouz.flo.Fn;
+import io.rouz.flo.Task;
+import io.rouz.flo.TaskContext;
+import io.rouz.flo.TaskId;
+import io.rouz.flo.context.ForwardingTaskContext;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * TODO: document.
+ */
+public class EvaluatingContext {
+
+  static final String OUTPUT_SUFFIX = "_out";
+
+  private final Path basePath;
+  private final TaskContext delegate;
+
+  public EvaluatingContext(Path basePath, TaskContext delegate) {
+    this.basePath = Objects.requireNonNull(basePath);
+    this.delegate = Objects.requireNonNull(delegate);
+  }
+
+  public <T> TaskContext.Value<T> evaluateTaskFrom(Path persistedTask) {
+    Task<T> task = null;
+    try {
+      task = PersistingContext.deserialize(persistedTask);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
+    return new SpecificEval(task, delegate).evaluate(task);
+  }
+
+  private Path resolveExistingOutput(TaskId taskId) {
+    final String fileName = cleanForFilename(taskId) + OUTPUT_SUFFIX;
+    return basePath.resolve(fileName);
+  }
+
+  private <T> void persist(TaskId taskId, T output) {
+    final Path outputPath = basePath.resolve(cleanForFilename(taskId) + OUTPUT_SUFFIX);
+
+    try {
+      PersistingContext.serialize(output, outputPath);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private class SpecificEval extends ForwardingTaskContext {
+
+    private final Task<?> evalTask;
+
+    protected SpecificEval(Task<?> evalTask, TaskContext delegate) {
+      super(delegate);
+      this.evalTask = evalTask;
+    }
+
+    @Override
+    public <T> Value<T> evaluateInternal(Task<T> task, TaskContext context) {
+      final Promise<T> promise = promise();
+      final TaskId id = task.id();
+      final Set<TaskId> inputTaskIds = evalTask.inputs().stream()
+          .map(Task::id)
+          .collect(Collectors.toSet());
+
+      if (inputTaskIds.contains(id)) {
+        final Path inputValuePath = resolveExistingOutput(id);
+        if (Files.exists(inputValuePath)) {
+          final T value;
+          try {
+            value = PersistingContext.deserialize(inputValuePath);
+            promise.set(value);
+          } catch (Exception e) {
+            promise.fail(e);
+          }
+        } else {
+          promise.fail(new RuntimeException("Output value for input task " + id + " not found"));
+        }
+      } else if (!id.equals(evalTask.id())) {
+        promise.fail(new RuntimeException("Evaluation of unexpected task: " + id));
+      } else {
+        final Value<T> tValue = super.evaluateInternal(task, context);
+        tValue.consume(v -> persist(evalTask.id(), v));
+        tValue.consume(promise::set);
+        tValue.onFail(promise::fail);
+      }
+
+      return promise.value();
+    }
+
+    @Override
+    public <T> Value<T> invokeProcessFn(TaskId taskId, Fn<Value<T>> processFn) {
+      // todo: only invoke fn if taskId == evalTask
+      // todo: fail if called for taskId != evalTask
+
+      final Value<T> tValue = super.invokeProcessFn(taskId, processFn);
+      tValue.consume(v -> LOG.info("{} == {}", colored(taskId), v));
+      return tValue;
+    }
+  }
+}

--- a/flo-freezer/src/main/java/io/rouz/flo/freezer/LoggingListener.java
+++ b/flo-freezer/src/main/java/io/rouz/flo/freezer/LoggingListener.java
@@ -11,7 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * TODO: document.
+ * A {@link InstrumentedContext.Listener} that prints to an slf4j Logger.
  */
 public class LoggingListener implements InstrumentedContext.Listener {
 

--- a/flo-freezer/src/main/java/io/rouz/flo/freezer/LoggingListener.java
+++ b/flo-freezer/src/main/java/io/rouz/flo/freezer/LoggingListener.java
@@ -1,0 +1,43 @@
+package io.rouz.flo.freezer;
+
+import static org.fusesource.jansi.Ansi.Color.CYAN;
+import static org.fusesource.jansi.Ansi.Color.WHITE;
+import static org.fusesource.jansi.Ansi.ansi;
+
+import io.rouz.flo.TaskId;
+import io.rouz.flo.context.InstrumentedContext;
+import org.fusesource.jansi.Ansi;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * TODO: document.
+ */
+public class LoggingListener implements InstrumentedContext.Listener {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LoggingListener.class);
+
+  @Override
+  public void edge(TaskId upstream, TaskId downstream) {
+    LOG.info("{} <- {}", colored(upstream), colored(downstream));
+  }
+
+  @Override
+  public void status(TaskId task, Phase phase) {
+    LOG.info("{} :: {}", colored(task), phase);
+  }
+
+  public static Ansi colored(TaskId taskId) {
+    final String id = taskId.toString();
+    final int openParen = id.indexOf('(');
+    final int closeParen = id.lastIndexOf(')');
+    final int hashPos = id.lastIndexOf('#');
+
+    return ansi()
+        .fg(CYAN).a(id.substring(0, openParen + 1))
+        .reset().a(id.substring(openParen + 1, closeParen))
+        .fg(CYAN).a(id.substring(closeParen, hashPos))
+        .fg(WHITE).a(id.substring(hashPos))
+        .reset();
+  }
+}

--- a/flo-freezer/src/main/java/io/rouz/flo/freezer/LoggingListener.java
+++ b/flo-freezer/src/main/java/io/rouz/flo/freezer/LoggingListener.java
@@ -1,12 +1,9 @@
 package io.rouz.flo.freezer;
 
-import static org.fusesource.jansi.Ansi.Color.CYAN;
-import static org.fusesource.jansi.Ansi.Color.WHITE;
-import static org.fusesource.jansi.Ansi.ansi;
+import static io.rouz.flo.Util.colored;
 
 import io.rouz.flo.TaskId;
 import io.rouz.flo.context.InstrumentedContext;
-import org.fusesource.jansi.Ansi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,19 +22,5 @@ public class LoggingListener implements InstrumentedContext.Listener {
   @Override
   public void status(TaskId task, Phase phase) {
     LOG.info("{} :: {}", colored(task), phase);
-  }
-
-  public static Ansi colored(TaskId taskId) {
-    final String id = taskId.toString();
-    final int openParen = id.indexOf('(');
-    final int closeParen = id.lastIndexOf(')');
-    final int hashPos = id.lastIndexOf('#');
-
-    return ansi()
-        .fg(CYAN).a(id.substring(0, openParen + 1))
-        .reset().a(id.substring(openParen + 1, closeParen))
-        .fg(CYAN).a(id.substring(closeParen, hashPos))
-        .fg(WHITE).a(id.substring(hashPos))
-        .reset();
   }
 }

--- a/flo-freezer/src/main/java/io/rouz/flo/freezer/Persisted.java
+++ b/flo-freezer/src/main/java/io/rouz/flo/freezer/Persisted.java
@@ -1,0 +1,8 @@
+package io.rouz.flo.freezer;
+
+/**
+ * This exception is thrown in the {@link io.rouz.flo.TaskContext.Value} that is created by
+ * {@link PersistingContext}.
+ */
+public class Persisted extends RuntimeException {
+}

--- a/flo-freezer/src/main/java/io/rouz/flo/freezer/PersistingContext.java
+++ b/flo-freezer/src/main/java/io/rouz/flo/freezer/PersistingContext.java
@@ -70,7 +70,7 @@ public class PersistingContext extends ForwardingTaskContext {
   public <T> Value<T> invokeProcessFn(TaskId taskId, Fn<Value<T>> processFn) {
     final Promise<T> promise = promise();
     LOG.info("Will not invoke {}", colored(taskId));
-    promise.fail(new RuntimeException("will not invoke"));
+    promise.fail(new Persisted());
     return promise.value();
   }
 

--- a/flo-freezer/src/main/java/io/rouz/flo/freezer/PersistingContext.java
+++ b/flo-freezer/src/main/java/io/rouz/flo/freezer/PersistingContext.java
@@ -1,6 +1,6 @@
 package io.rouz.flo.freezer;
 
-import static io.rouz.flo.freezer.LoggingListener.colored;
+import static io.rouz.flo.Util.colored;
 import static java.nio.file.Files.newInputStream;
 import static java.nio.file.Files.newOutputStream;
 import static java.nio.file.StandardOpenOption.CREATE_NEW;

--- a/flo-freezer/src/main/java/io/rouz/flo/freezer/PersistingContext.java
+++ b/flo-freezer/src/main/java/io/rouz/flo/freezer/PersistingContext.java
@@ -1,0 +1,109 @@
+package io.rouz.flo.freezer;
+
+import static io.rouz.flo.freezer.LoggingListener.colored;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.serializers.ClosureSerializer;
+import io.rouz.flo.Fn;
+import io.rouz.flo.Task;
+import io.rouz.flo.TaskContext;
+import io.rouz.flo.TaskId;
+import io.rouz.flo.context.ForwardingTaskContext;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.objenesis.strategy.StdInstantiatorStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * TODO: document.
+ */
+public class PersistingContext extends ForwardingTaskContext {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PersistingContext.class);
+
+  private final Path basePath;
+  private final Map<TaskId, Path> files = new LinkedHashMap<>();
+
+  public PersistingContext(Path basePath, TaskContext delegate) {
+    super(delegate);
+    this.basePath = Objects.requireNonNull(basePath);
+  }
+
+  public Map<TaskId, Path> getFiles() {
+    return files;
+  }
+
+  @Override
+  public <T> Value<T> evaluateInternal(Task<T> task, TaskContext context) {
+    Path file = tempFile(task.id());
+    files.put(task.id(), file);
+    try {
+      serialize(task, file);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
+    return super.evaluateInternal(task, context);
+  }
+
+  @Override
+  public <T> Value<T> invokeProcessFn(TaskId taskId, Fn<Value<T>> processFn) {
+    final Promise<T> promise = promise();
+    LOG.info("Will not invoke {}", colored(taskId));
+    promise.fail(new RuntimeException("will not invoke"));
+    return promise.value();
+  }
+
+  public static void serialize(Object object, Path file) throws Exception{
+    final Kryo kryo = new Kryo();
+    kryo.register(java.lang.invoke.SerializedLambda.class);
+    kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());
+
+    final File outputFil = file.toFile();
+    if (!outputFil.createNewFile()) {
+      throw new RuntimeException("File " + file + " already exists");
+    }
+
+    try {
+      try (Output output = new Output(new FileOutputStream(outputFil))) {
+        kryo.writeClassAndObject(output, object);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static <T> T deserialize(Path filePath) throws Exception {
+    Kryo kryo = new Kryo();
+    kryo.register(java.lang.invoke.SerializedLambda.class);
+    kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());
+    kryo.setInstantiatorStrategy(new Kryo.DefaultInstantiatorStrategy(new StdInstantiatorStrategy()));
+
+    try (InputStream inputStream = new FileInputStream(filePath.toFile())) {
+      Input input = new Input(inputStream);
+      return (T) kryo.readClassAndObject(input);
+    }
+  }
+
+  public static String cleanForFilename(TaskId taskId) {
+    return taskId.toString()
+        .toLowerCase()
+        .replaceAll("[,#()]+", "_")
+        .replaceAll("[^a-z0-9_]*", "")
+    ;
+  }
+
+  private Path tempFile(TaskId taskId) {
+    return basePath.resolve(cleanForFilename(taskId));
+  }
+}

--- a/flo-freezer/src/main/java/io/rouz/flo/freezer/PersistingContext.java
+++ b/flo-freezer/src/main/java/io/rouz/flo/freezer/PersistingContext.java
@@ -51,7 +51,10 @@ public class PersistingContext extends ForwardingTaskContext {
 
   @Override
   public <T> Value<T> evaluateInternal(Task<T> task, TaskContext context) {
-    Path file = tempFile(task.id());
+    // materialize lazy inputs
+    task.inputs();
+
+    Path file = taskFile(task.id());
     files.put(task.id(), file);
     try {
       serialize(task, file);
@@ -109,7 +112,7 @@ public class PersistingContext extends ForwardingTaskContext {
     ;
   }
 
-  private Path tempFile(TaskId taskId) {
+  private Path taskFile(TaskId taskId) {
     return basePath.resolve(cleanForFilename(taskId));
   }
 }

--- a/flo-freezer/src/main/java/io/rouz/flo/freezer/PersistingContext.java
+++ b/flo-freezer/src/main/java/io/rouz/flo/freezer/PersistingContext.java
@@ -25,7 +25,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * TODO: document.
+ * A {@link TaskContext} that serializes and persist tasks. Any call to {@link #evaluate(Task)}
+ * will persist the task and recurse to also do so for all input tasks. No task in the dependency
+ * tree will actually be invoked. Instead {@link #evaluate(Task)} will return a {@link Value} that
+ * always fails.
+ *
+ * <p>After the returned {@link Value} has failed, all persisted file paths can be received through
+ * {@link #getFiles()}.
  */
 public class PersistingContext extends ForwardingTaskContext {
 

--- a/flo-freezer/src/main/java/io/rouz/flo/freezer/TaskRunnerEntrypoint.java
+++ b/flo-freezer/src/main/java/io/rouz/flo/freezer/TaskRunnerEntrypoint.java
@@ -11,7 +11,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * TODO: document.
+ * A main class that uses {@link EvaluatingContext} for evaluating a specific task which has
+ * been persisted by {@link PersistingContext}. It expects the inputs to the task to already
+ * have been evaluated using the same method.
+ *
+ * <p>After evaluation of the specified task has completed, the output value will be stored as a
+ * sibling file to the persisted task file, with an added "_out" suffix.
  */
 public class TaskRunnerEntrypoint {
 
@@ -31,7 +36,7 @@ public class TaskRunnerEntrypoint {
             InstrumentedContext.composeWith(
                 TaskContext.inmem(), new LoggingListener())));
 
-    final AwaitingConsumer < Object > res = AwaitingConsumer.create();
+    final AwaitingConsumer<Object> res = AwaitingConsumer.create();
     final TaskContext.Value<Object> value = evaluatingContext.evaluateTaskFrom(filePath);
     value.consume(res);
     value.onFail(Throwable::printStackTrace);

--- a/flo-freezer/src/main/java/io/rouz/flo/freezer/TaskRunnerEntrypoint.java
+++ b/flo-freezer/src/main/java/io/rouz/flo/freezer/TaskRunnerEntrypoint.java
@@ -1,0 +1,44 @@
+package io.rouz.flo.freezer;
+
+import io.rouz.flo.TaskContext;
+import io.rouz.flo.context.AwaitingConsumer;
+import io.rouz.flo.context.InstrumentedContext;
+import io.rouz.flo.context.MemoizingContext;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * TODO: document.
+ */
+public class TaskRunnerEntrypoint {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TaskRunnerEntrypoint.class);
+
+  public static void main(String[] args) throws InterruptedException {
+    if (args.length < 1) {
+      LOG.info("Usage: flo-task-runner <persisted-task-file>");
+      System.exit(1);
+    }
+
+    final String file = args[0];
+    final Path filePath = Paths.get(file);
+
+    final EvaluatingContext evaluatingContext = new EvaluatingContext(
+        filePath.resolveSibling(""), MemoizingContext.composeWith(
+            InstrumentedContext.composeWith(
+                TaskContext.inmem(), new LoggingListener())));
+
+    final AwaitingConsumer < Object > res = AwaitingConsumer.create();
+    final TaskContext.Value<Object> value = evaluatingContext.evaluateTaskFrom(filePath);
+    value.consume(res);
+    value.onFail(Throwable::printStackTrace);
+
+    res.await(5, TimeUnit.SECONDS);
+    final Object output = res.get();
+
+    LOG.info("res.get() = " + output);
+  }
+}

--- a/flo-freezer/src/main/java/io/rouz/flo/freezer/TaskRunnerEntrypoint.java
+++ b/flo-freezer/src/main/java/io/rouz/flo/freezer/TaskRunnerEntrypoint.java
@@ -4,6 +4,7 @@ import io.rouz.flo.TaskContext;
 import io.rouz.flo.context.AwaitingConsumer;
 import io.rouz.flo.context.InstrumentedContext;
 import io.rouz.flo.context.MemoizingContext;
+import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
@@ -29,7 +30,8 @@ public class TaskRunnerEntrypoint {
     }
 
     final String file = args[0];
-    final Path filePath = Paths.get(file);
+    final URI fileUri = URI.create(file);
+    final Path filePath = Paths.get(fileUri);
 
     final EvaluatingContext evaluatingContext = new EvaluatingContext(
         filePath.resolveSibling(""), MemoizingContext.composeWith(

--- a/flo-freezer/src/test/java/io/rouz/flo/freezer/EvaluatingContextTest.java
+++ b/flo-freezer/src/test/java/io/rouz/flo/freezer/EvaluatingContextTest.java
@@ -1,0 +1,121 @@
+package io.rouz.flo.freezer;
+
+import static io.rouz.flo.TaskContext.inmem;
+import static io.rouz.flo.freezer.EvaluatingContext.OUTPUT_SUFFIX;
+import static io.rouz.flo.freezer.PersistingContext.cleanForFilename;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import io.rouz.flo.Task;
+import io.rouz.flo.TaskContext;
+import io.rouz.flo.TaskId;
+import io.rouz.flo.context.AwaitingConsumer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class EvaluatingContextTest {
+
+  @Rule
+  public ExpectedException expect = ExpectedException.none();
+
+  private Path basePath;
+  private PersistingContext persistingContext;
+
+  private EvaluatingContext evaluatingContext;
+
+  @Before
+  public void setUp() throws Exception {
+    basePath = Files.createTempDirectory("SpecificEvalTest");
+    persistingContext = new PersistingContext(basePath, inmem());
+    evaluatingContext = new EvaluatingContext(basePath, inmem());
+  }
+
+  @Test
+  public void evaluatesPersistedTask() throws Exception {
+    Task<String> task = singleTask("world");
+    Path persistedPath = persist(task).get(task.id());
+
+    AwaitingConsumer<String> await = AwaitingConsumer.create();
+    evaluatingContext.<String>evaluateTaskFrom(persistedPath).consume(await);
+
+    String output = await.awaitAndGet();
+    assertThat(output, is("hello world"));
+  }
+
+  @Test
+  public void persistsOutputOfEvaluatedTask() throws Exception {
+    Task<String> task = singleTask("world");
+    Path persistedPath = persist(task).get(task.id());
+
+    AwaitingConsumer<String> await = AwaitingConsumer.create();
+    final TaskContext.Value<String> stringValue =
+        evaluatingContext.evaluateTaskFrom(persistedPath);
+    stringValue.consume(await);
+    stringValue.onFail(Throwable::printStackTrace);
+
+    await.awaitAndGet();
+    assertTrue(Files.exists(basePath.resolve(cleanForFilename(task.id()) + OUTPUT_SUFFIX)));
+  }
+
+  @Test
+  public void failsIfTaskHasUnevaluatedInputs() throws Throwable {
+    Task<String> task = downstreamTask("world");
+    Map<TaskId, Path> persistedPaths = persist(task);
+
+    AwaitingConsumer<Throwable> awaitFailure = AwaitingConsumer.create();
+    Path downstreamPath = persistedPaths.get(task.id());
+    final TaskContext.Value<String> stringValue =
+        evaluatingContext.evaluateTaskFrom(downstreamPath);
+    stringValue.onFail(awaitFailure);
+
+    expect.expect(RuntimeException.class);
+    expect.expectMessage("Output value for input task " + singleTask("world").id() + " not found");
+
+    throw awaitFailure.awaitAndGet();
+  }
+
+  @Test
+  public void readsPersistedInputValues() throws Exception {
+    Task<String> task = downstreamTask("world");
+    Map<TaskId, Path> persistedPaths = persist(task);
+
+    AwaitingConsumer<String> awaitUpstream = AwaitingConsumer.create();
+    Path upstreamPath = persistedPaths.get(singleTask("world").id());
+    evaluatingContext.<String>evaluateTaskFrom(upstreamPath)
+        .consume(awaitUpstream);
+    awaitUpstream.awaitAndGet();
+
+    AwaitingConsumer<String> await = AwaitingConsumer.create();
+    Path downstreamPath = persistedPaths.get(task.id());
+    final TaskContext.Value<String> stringValue =
+        evaluatingContext.evaluateTaskFrom(downstreamPath);
+    stringValue.consume(await);
+    stringValue.onFail(Throwable::printStackTrace);
+
+    assertThat(await.awaitAndGet(), is("hello world!"));
+  }
+
+  private static Task<String> singleTask(String arg) {
+    return Task.named("single", arg).ofType(String.class)
+        .process(() -> "hello " + arg);
+  }
+
+  private static Task<String> downstreamTask(String arg) {
+    return Task.named("downstream", arg).ofType(String.class)
+        .in(() -> singleTask(arg))
+        .process((in) -> in + "!");
+  }
+
+  private Map<TaskId, Path> persist(Task<String> task) {
+    AwaitingConsumer<Throwable> awaitPersist = AwaitingConsumer.create();
+    persistingContext.evaluate(task).onFail(awaitPersist); // persistingContext fails all evals
+
+    return persistingContext.getFiles();
+  }
+}

--- a/flo-freezer/src/test/java/io/rouz/flo/freezer/EvaluatingContextTest.java
+++ b/flo-freezer/src/test/java/io/rouz/flo/freezer/EvaluatingContextTest.java
@@ -25,9 +25,9 @@ public class EvaluatingContextTest {
   @Rule
   public ExpectedException expect = ExpectedException.none();
 
-  private Path basePath;
-  private PersistingContext persistingContext;
+  Path basePath;
 
+  private PersistingContext persistingContext;
   private EvaluatingContext evaluatingContext;
 
   private static boolean calledInputCode;
@@ -119,12 +119,12 @@ public class EvaluatingContextTest {
     assertFalse(calledInputCode);
   }
 
-  private static Task<String> singleTask(String arg) {
+  static Task<String> singleTask(String arg) {
     return Task.named("single", arg).ofType(String.class)
         .process(() -> "hello " + arg);
   }
 
-  private static Task<String> downstreamTask(String arg) {
+  static Task<String> downstreamTask(String arg) {
     return Task.named("downstream", arg).ofType(String.class)
         .in(() -> {
           calledInputCode = true;
@@ -133,7 +133,7 @@ public class EvaluatingContextTest {
         .process((in) -> in + "!");
   }
 
-  private Map<TaskId, Path> persist(Task<String> task) {
+  Map<TaskId, Path> persist(Task<String> task) {
     AwaitingConsumer<Throwable> awaitPersist = AwaitingConsumer.create();
     persistingContext.evaluate(task).onFail(awaitPersist); // persistingContext fails all evals
 

--- a/flo-freezer/src/test/java/io/rouz/flo/freezer/TaskRunnerEntrypointTest.java
+++ b/flo-freezer/src/test/java/io/rouz/flo/freezer/TaskRunnerEntrypointTest.java
@@ -1,0 +1,31 @@
+package io.rouz.flo.freezer;
+
+import static io.rouz.flo.freezer.EvaluatingContext.OUTPUT_SUFFIX;
+import static io.rouz.flo.freezer.PersistingContext.cleanForFilename;
+import static org.junit.Assert.assertTrue;
+
+import io.rouz.flo.Task;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TaskRunnerEntrypointTest {
+
+  private EvaluatingContextTest subTest = new EvaluatingContextTest();
+
+  @Before
+  public void setUp() throws Exception {
+    subTest.setUp();
+  }
+
+  @Test
+  public void evalEntrypointShouldProduceOutputOfTask() throws Exception {
+    Task<String> task = EvaluatingContextTest.singleTask("world");
+    Path persistedPath = subTest.persist(task).get(task.id());
+
+    TaskRunnerEntrypoint.main(new String[]{persistedPath.toUri().toString()});
+
+    assertTrue(Files.exists(subTest.basePath.resolve(cleanForFilename(task.id()) + OUTPUT_SUFFIX)));
+  }
+}

--- a/flo-task-runner/pom.xml
+++ b/flo-task-runner/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>flo</artifactId>
+    <groupId>io.rouz</groupId>
+    <version>0.0.10-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>flo-task-runner</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.rouz</groupId>
+      <artifactId>flo-workflow</artifactId>
+      <version>0.0.10-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>io.rouz</groupId>
+      <artifactId>flo-freezer</artifactId>
+      <version>0.0.10-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>io.rouz.flo.TestWorkflow</mainClass>
+                </transformer>
+              </transformers>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/flo-task-runner/src/main/java/io/rouz/flo/TestWorkflow.java
+++ b/flo-task-runner/src/main/java/io/rouz/flo/TestWorkflow.java
@@ -1,0 +1,87 @@
+package io.rouz.flo;
+
+import static io.rouz.flo.TaskContext.inmem;
+import static io.rouz.flo.freezer.LoggingListener.colored;
+
+import io.rouz.flo.TaskContext.Value;
+import io.rouz.flo.context.AwaitingConsumer;
+import io.rouz.flo.context.InstrumentedContext;
+import io.rouz.flo.context.MemoizingContext;
+import io.rouz.flo.freezer.LoggingListener;
+import io.rouz.flo.freezer.PersistingContext;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * TODO: document.
+ */
+public class TestWorkflow {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestWorkflow.class);
+
+  public static void main(String[] args) throws InterruptedException {
+    Task<Long> fib9 = fib(9);
+    persist(fib9);
+  }
+
+  public static Task<Long> fib(long n) {
+    TaskBuilder<Long> fib = Task.named("Fib", n).ofType(Long.class);
+    if (n < 2) {
+      return fib
+          .process(() -> n);
+    } else {
+      return fib
+          .in(() -> fib(n - 1))
+          .in(() -> fib(n - 2))
+          .process(TestWorkflow::fib);
+    }
+  }
+
+  static long fib(long a, long b) {
+    LOG.info("Fib.process(" + a + " + " + b + ") = " + (a + b));
+    return a + b;
+  }
+
+  private static void persist(Task<?> task) throws InterruptedException {
+    final String cwd = System.getProperty("user.dir");
+    final Path basePath = Paths.get(cwd).resolve("run-" + randomAlphaNumeric(4));
+
+    try {
+      Files.createDirectories(basePath);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    PersistingContext persistingContext = new PersistingContext(basePath, inmem());
+    TaskContext context = MemoizingContext.composeWith(
+        InstrumentedContext.composeWith(
+            persistingContext, new LoggingListener()));
+
+    AwaitingConsumer<Throwable> await = AwaitingConsumer.create();
+    Value<?> value = context.evaluate(task);
+    value.onFail(await);
+
+    await.await(5, TimeUnit.SECONDS);
+    Map<TaskId, Path> files = persistingContext.getFiles();
+    files.forEach((taskId, file) ->
+        LOG.info("{} -> {}", colored(taskId), file)
+    );
+  }
+
+  private static final String ALPHA_NUMERIC_STRING = "abcdefghijklmnopqrstuvwxyz0123456789";
+
+  public static String randomAlphaNumeric(int count) {
+    StringBuilder builder = new StringBuilder();
+    while (count-- != 0) {
+      int character = (int)(Math.random() * ALPHA_NUMERIC_STRING.length());
+      builder.append(ALPHA_NUMERIC_STRING.charAt(character));
+    }
+    return builder.toString();
+  }
+}

--- a/flo-task-runner/src/main/java/io/rouz/flo/TestWorkflow.java
+++ b/flo-task-runner/src/main/java/io/rouz/flo/TestWorkflow.java
@@ -1,7 +1,7 @@
 package io.rouz.flo;
 
 import static io.rouz.flo.TaskContext.async;
-import static io.rouz.flo.freezer.LoggingListener.colored;
+import static io.rouz.flo.Util.colored;
 import static java.lang.System.getProperty;
 import static java.lang.System.getenv;
 

--- a/flo-task-runner/src/main/java/io/rouz/flo/TestWorkflow.java
+++ b/flo-task-runner/src/main/java/io/rouz/flo/TestWorkflow.java
@@ -18,9 +18,6 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * TODO: document.
- */
 public class TestWorkflow {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestWorkflow.class);

--- a/flo-task-runner/src/main/resources/logback.xml
+++ b/flo-task-runner/src/main/resources/logback.xml
@@ -1,0 +1,9 @@
+<configuration debug="false">
+  <root level="debug">
+    <appender class="ch.qos.logback.core.ConsoleAppender">
+      <encoder>
+        <pattern>%msg%n</pattern>
+      </encoder>
+    </appender>
+  </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,8 @@
         <module>cli</module>
         <module>test</module>
         <module>flo-scala</module>
+        <module>flo-task-runner</module>
+        <module>flo-freezer</module>
     </modules>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,11 @@
                 <version>1.7.16</version>
             </dependency>
             <dependency>
+                <groupId>org.fusesource.jansi</groupId>
+                <artifactId>jansi</artifactId>
+                <version>1.11</version>
+            </dependency>
+            <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>1.1.3</version>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -13,6 +13,11 @@
     <dependencies>
         <dependency>
             <groupId>io.rouz</groupId>
+            <artifactId>flo-workflow</artifactId>
+            <version>0.0.10-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.rouz</groupId>
             <artifactId>flo-cli</artifactId>
             <version>0.0.10-SNAPSHOT</version>
         </dependency>
@@ -46,6 +51,11 @@
         <dependency>
             <groupId>com.google.truth</groupId>
             <artifactId>truth</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/test/src/main/java/io/rouz/scratch/Scratch.java
+++ b/test/src/main/java/io/rouz/scratch/Scratch.java
@@ -1,14 +1,6 @@
 package io.rouz.scratch;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import io.rouz.flo.Task;
-import io.rouz.flo.TaskContext;
-import io.rouz.flo.TaskId;
-import io.rouz.flo.TaskInfo;
-import io.rouz.flo.context.AwaitingConsumer;
-import io.rouz.flo.context.InstrumentedContext;
-import io.rouz.flo.context.MemoizingContext;
 import io.rouz.flo.proc.Exec;
 import io.rouz.flo.processor.RootTask;
 
@@ -44,32 +36,6 @@ public class Scratch {
     foo.inputsInOrder()
         .map(Task::id)
         .forEachOrdered(System.out::println);
-
-    TaskInfo taskInfo = TaskInfo.ofTask(foo);
-    ObjectMapper objectMapper = new ObjectMapper()
-        .enable(SerializationFeature.INDENT_OUTPUT);
-    String json = objectMapper.writeValueAsString(taskInfo);
-    System.out.println(json);
-
-    AwaitingConsumer<Exec.Result> result = AwaitingConsumer.create();
-    TaskContext ctx = MemoizingContext.composeWith(
-        InstrumentedContext.composeWith(
-            TaskContext.inmem(), new L()));
-    ctx.evaluate(foo).consume(result);
-    result.awaitAndGet();
-  }
-
-  static class L implements InstrumentedContext.Listener {
-
-    @Override
-    public void edge(TaskId upstream, TaskId downstream) {
-      System.out.println(upstream + " <- " + downstream);
-    }
-
-    @Override
-    public void status(TaskId task, Phase phase) {
-      System.out.println(task + " :: " + phase);
-    }
   }
 
   @RootTask

--- a/workflow/pom.xml
+++ b/workflow/pom.xml
@@ -27,6 +27,10 @@
             <artifactId>jopt-simple</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.fusesource.jansi</groupId>
+            <artifactId>jansi</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/workflow/src/main/java/io/rouz/flo/Util.java
+++ b/workflow/src/main/java/io/rouz/flo/Util.java
@@ -1,0 +1,27 @@
+package io.rouz.flo;
+
+import static org.fusesource.jansi.Ansi.Color.CYAN;
+import static org.fusesource.jansi.Ansi.Color.WHITE;
+import static org.fusesource.jansi.Ansi.ansi;
+
+import org.fusesource.jansi.Ansi;
+
+public final class Util {
+
+  private Util() {
+  }
+
+  public static Ansi colored(TaskId taskId) {
+    final String id = taskId.toString();
+    final int openParen = id.indexOf('(');
+    final int closeParen = id.lastIndexOf(')');
+    final int hashPos = id.lastIndexOf('#');
+
+    return ansi()
+        .fg(CYAN).a(id.substring(0, openParen + 1))
+        .reset().a(id.substring(openParen + 1, closeParen))
+        .fg(CYAN).a(id.substring(closeParen, hashPos))
+        .fg(WHITE).a(id.substring(hashPos))
+        .reset();
+  }
+}

--- a/workflow/src/main/java/io/rouz/flo/context/AwaitingConsumer.java
+++ b/workflow/src/main/java/io/rouz/flo/context/AwaitingConsumer.java
@@ -43,7 +43,9 @@ public class AwaitingConsumer<T> implements Consumer<T> {
   }
 
   public T awaitAndGet() throws InterruptedException {
-    await();
+    if (!await()) {
+      throw new IllegalStateException("Value did not arrive");
+    }
     return value;
   }
 }

--- a/workflow/src/main/java/io/rouz/flo/context/MemoizingContext.java
+++ b/workflow/src/main/java/io/rouz/flo/context/MemoizingContext.java
@@ -1,5 +1,7 @@
 package io.rouz.flo.context;
 
+import static io.rouz.flo.Util.colored;
+
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -281,10 +283,10 @@ public class MemoizingContext extends ForwardingTaskContext {
       final Optional<T> lookup = memoizer.lookup(task);
       if (lookup.isPresent()) {
         final T t = lookup.get();
-        LOG.debug("Not expanding {}, lookup = {}", task.id(), t);
+        LOG.debug("Not expanding {}, lookup = {}", colored(task.id()), t);
         promise.set(t);
       } else {
-        LOG.debug("Expanding {}", task.id());
+        LOG.debug("Expanding {}", colored(task.id()));
         chain(delegate.evaluateInternal(task, context), promise);
       }
     }


### PR DESCRIPTION
Example usage of `PersistingContext` and `EvaluatingContext`. See also `TestWorkflow` and `TaskRunnerEntrypoint` in the PR.



```java
PersistingContext persistingContext = new PersistingContext(
    basePath, TaskContext.inmem());
TaskContext context = MemoizingContext.composeWith(persistingContext);

// evaluate, this will persist all tasks
Value<?> value = context.evaluate(task); 

// get all persisted file paths
Map<TaskId, Path> filePaths = persistingContext.getFiles();
```

```java
EvaluatingContext evaluatingContext = new EvaluatingContext(
    basePath, MemoizingContext.composeWith(TaskContext.inmem()));

// point-evaluate specific task
Value<?> value = evaluatingContext.evaluateTaskFrom(persistedFilePath);
```

---

@fabriziodemaria @bergman PTAL